### PR TITLE
v0.2.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,3 @@ updates:
     interval: daily
     time: "07:00"
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: rand_core
-    versions:
-    - 0.6.1

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 Cargo.lock
+
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
+### 0.2.0
+
+__Date:__ TBD
+
+__Changelog:__
+- Remove `Csprng` trait from public API and use `getrandom` instead
+- Update Orion to `0.16`
+
+
 ### 0.1.1 
 
 __Date:__ March 21, 2021.
 
 __Changelog:__
-
 - Switch from `base64` to `ct-codecs` to provide constant-time Base64 encoding/decoding
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 0.2.0
 
-__Date:__ TBD
+__Date:__ June 2, 2021.
 
 __Changelog:__
 - Remove `Csprng` trait from public API and use `getrandom` instead

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default-features = false
 features = ["u64_backend"]
 
 [dependencies.orion]
-version = "0.15.4"
+version = "0.16.0"
 default-features = false
 
 [dependencies.rand_core]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pasetors"
-version = "0.1.1" # Update html_root_url in lib.rs along with this.
+version = "0.2.0" # Update html_root_url in lib.rs along with this.
 authors = ["brycx <brycx@protonmail.com>"]
 edition = "2018"
 description = "PASETO: Platform-Agnostic Security Tokens (in Rust)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,8 @@ features = ["u64_backend"]
 version = "0.16.0"
 default-features = false
 
-[dependencies.rand_core]
-version = "0.5.1"
-default-features = false
-features = ["alloc"]
+[dependencies.getrandom]
+version = "0.2"
 
 [dependencies.ct-codecs]
 version = "1.1.1"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Tests](https://github.com/brycx/pasetors/workflows/Tests/badge.svg) [![Documentation](https://docs.rs/pasetors/badge.svg)](https://docs.rs/pasetors/) [![Crates.io](https://img.shields.io/crates/v/pasetors.svg)](https://crates.io/crates/pasetors) [![Safety Dance](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/) [![MSRV](https://img.shields.io/badge/MSRV-1.41-informational.svg)](https://img.shields.io/badge/MSRV-1.41-informational)
+![Tests](https://github.com/brycx/pasetors/workflows/Tests/badge.svg) [![Documentation](https://docs.rs/pasetors/badge.svg)](https://docs.rs/pasetors/) [![Crates.io](https://img.shields.io/crates/v/pasetors.svg)](https://crates.io/crates/pasetors) [![Safety Dance](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/) [![MSRV](https://img.shields.io/badge/MSRV-1.51-informational.svg)](https://img.shields.io/badge/MSRV-1.51-informational)
 
 ### PASETOrs
 
@@ -16,22 +16,20 @@ This library includes:
 ### Usage
 ```rust
 use pasetors::version2::*;
-use rand::RngCore;
 use ed25519_dalek::Keypair;
 
 let mut csprng = rand::rngs::OsRng{};
 
 // Create and verify a public token
 let keypair: Keypair = Keypair::generate(&mut csprng);
-let pub_token = PublicToken::sign(&keypair.secret.to_bytes(), &keypair.public.to_bytes(), 
-    b"Message to sign", Some(b"footer"))?;
+let pub_token = PublicToken::sign(&keypair.secret.to_bytes(), &keypair.public.to_bytes(), b"Message to sign", Some(b"footer"))?;
 assert!(PublicToken::verify(&keypair.public.to_bytes(), &pub_token, Some(b"footer")).is_ok());
 
 // Create and verify a local token
 let mut secret = [0u8; 32];
-csprng.try_fill_bytes(&mut secret)?;
+getrandom::getrandom(&mut secret)?;
 
-let local_token = LocalToken::encrypt(&mut csprng, &secret, b"Message to encrypt and authenticate", Some(b"footer"))?;
+let local_token = LocalToken::encrypt(&secret, b"Message to encrypt and authenticate", Some(b"footer"))?;
 assert!(LocalToken::decrypt(&secret, &local_token, Some(b"footer")).is_ok());
 ```
 
@@ -43,7 +41,7 @@ This library has **not undergone any third-party security audit**. Usage is at *
 The [ed25519-dalek](https://github.com/dalek-cryptography/ed25519-dalek) library, used for public tokens, was [included in an audit](https://blog.quarkslab.com/security-audit-of-dalek-libraries.html). The [orion](https://github.com/brycx/orion) library, used for local tokens, has **not** been audited.
 
 ### Minimum Supported Rust Version
-Rust 1.41 or later is supported however, the majority of testing happens with latest stable Rust.
+Rust 1.51 or later is supported however, the majority of testing happens with latest stable Rust.
 
 MSRV may be changed at any point and will not be considered a SemVer breaking change.
 

--- a/fuzz/fuzz_targets/fuzz_pasetors.rs
+++ b/fuzz/fuzz_targets/fuzz_pasetors.rs
@@ -42,7 +42,7 @@ fuzz_target!(|data: &[u8]| {
     }
 
     let local_token =
-        version2::LocalToken::encrypt(&mut csprng, key.as_ref(), message.as_bytes(), None).unwrap();
+        version2::LocalToken::encrypt(key.as_ref(), message.as_bytes(), None).unwrap();
     if !version2::LocalToken::decrypt(key.as_ref(), &local_token, None).is_ok() {
         panic!("Valid token was NOT verified");
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,8 +23,8 @@ impl From<ct_codecs::Error> for Errors {
     }
 }
 
-impl From<rand_core::Error> for Errors {
-    fn from(_: rand_core::Error) -> Self {
+impl From<getrandom::Error> for Errors {
+    fn from(_: getrandom::Error) -> Self {
         Errors::CsprngError
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
     unused_qualifications,
     overflowing_literals
 )]
-#![doc(html_root_url = "https://docs.rs/pasetors/0.1.1")]
+#![doc(html_root_url = "https://docs.rs/pasetors/0.2.0")]
 
 #[macro_use]
 extern crate alloc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 //! # Usage:
 //! ```rust
 //! use pasetors::version2::*;
-//! use rand::RngCore;
 //! use ed25519_dalek::Keypair;
 //!
 //! let mut csprng = rand::rngs::OsRng{};
@@ -13,9 +12,9 @@
 //!
 //! // Create and verify a local token
 //! let mut secret = [0u8; 32];
-//! csprng.try_fill_bytes(&mut secret)?;
+//! getrandom::getrandom(&mut secret)?;
 //!
-//! let local_token = LocalToken::encrypt(&mut csprng, &secret, b"Message to encrypt and authenticate", Some(b"footer"))?;
+//! let local_token = LocalToken::encrypt(&secret, b"Message to encrypt and authenticate", Some(b"footer"))?;
 //! assert!(LocalToken::decrypt(&secret, &local_token, Some(b"footer")).is_ok());
 //!
 //! # Ok::<(), pasetors::errors::Errors>(())

--- a/src/version2.rs
+++ b/src/version2.rs
@@ -157,7 +157,7 @@ impl LocalToken {
 
     /// Encrypt and authenticate a message using nonce_key_bytes to derive a nonce
     /// using BLAKE2b.
-    fn encrypt_with_nonce(
+    fn encrypt_with_derived_nonce(
         secret_key: &[u8],
         nonce_key_bytes: &[u8],
         message: &[u8],
@@ -221,7 +221,7 @@ impl LocalToken {
         let mut rng_bytes = [0u8; XCHACHA_NONCESIZE];
         csprng.try_fill_bytes(&mut rng_bytes)?;
 
-        Self::encrypt_with_nonce(secret_key, &rng_bytes, message, footer)
+        Self::encrypt_with_derived_nonce(secret_key, &rng_bytes, message, footer)
     }
 
     /// Verify and decrypt a local token.
@@ -495,10 +495,13 @@ mod test_local {
         let expected = "v2.local.97TTOvgwIxNGvV80XKiGZg_kD3tsXM_-qB4dZGHOeN1cTkgQ4PnW8888l802W8d9AvEGnoNBY3BnqHORy8a5cC8aKpbA0En8XELw2yDk2f1sVODyfnDbi6rEGMY3pSfCbLWMM2oHJxvlEl2XbQ";
         let footer = b"";
 
-        assert!(
-            LocalToken::encrypt_with_nonce(&TEST_SK[..31], &TEST_NONCE, message, Some(footer))
-                .is_err()
-        );
+        assert!(LocalToken::encrypt_with_derived_nonce(
+            &TEST_SK[..31],
+            &TEST_NONCE,
+            message,
+            Some(footer)
+        )
+        .is_err());
         assert!(LocalToken::encrypt(&mut csprng, &TEST_SK[..31], message, Some(footer)).is_err());
         assert!(LocalToken::decrypt(&TEST_SK[..31], expected, Some(footer)).is_err());
     }
@@ -523,9 +526,10 @@ mod test_local {
         let footer = b"";
 
         let actual_some =
-            LocalToken::encrypt_with_nonce(&TEST_SK, &TEST_NONCE, message, Some(footer)).unwrap();
+            LocalToken::encrypt_with_derived_nonce(&TEST_SK, &TEST_NONCE, message, Some(footer))
+                .unwrap();
         let actual_none =
-            LocalToken::encrypt_with_nonce(&TEST_SK, &TEST_NONCE, message, None).unwrap();
+            LocalToken::encrypt_with_derived_nonce(&TEST_SK, &TEST_NONCE, message, None).unwrap();
 
         assert_eq!(actual_some, actual_none);
         assert_eq!(actual_some, expected);
@@ -540,7 +544,8 @@ mod test_local {
         let expected = "v2.local.97TTOvgwIxNGvV80XKiGZg_kD3tsXM_-qB4dZGHOeN1cTkgQ4PnW8888l802W8d9AvEGnoNBY3BnqHORy8a5cC8aKpbA0En8XELw2yDk2f1sVODyfnDbi6rEGMY3pSfCbLWMM2oHJxvlEl2XbQ";
         let footer = b"";
         let actual =
-            LocalToken::encrypt_with_nonce(&TEST_SK, &TEST_NONCE, message, Some(footer)).unwrap();
+            LocalToken::encrypt_with_derived_nonce(&TEST_SK, &TEST_NONCE, message, Some(footer))
+                .unwrap();
 
         assert_eq!(expected, actual);
         assert_eq!(
@@ -556,7 +561,8 @@ mod test_local {
         let expected = "v2.local.CH50H-HM5tzdK4kOmQ8KbIvrzJfjYUGuu5Vy9ARSFHy9owVDMYg3-8rwtJZQjN9ABHb2njzFkvpr5cOYuRyt7CRXnHt42L5yZ7siD-4l-FoNsC7J2OlvLlIwlG06mzQVunrFNb7Z3_CHM0PK5w";
         let footer = b"";
         let actual =
-            LocalToken::encrypt_with_nonce(&TEST_SK, &TEST_NONCE, message, Some(footer)).unwrap();
+            LocalToken::encrypt_with_derived_nonce(&TEST_SK, &TEST_NONCE, message, Some(footer))
+                .unwrap();
 
         assert_eq!(expected, actual);
         assert_eq!(
@@ -572,7 +578,8 @@ mod test_local {
         let expected = "v2.local.5K4SCXNhItIhyNuVIZcwrdtaDKiyF81-eWHScuE0idiVqCo72bbjo07W05mqQkhLZdVbxEa5I_u5sgVk1QLkcWEcOSlLHwNpCkvmGGlbCdNExn6Qclw3qTKIIl5-O5xRBN076fSDPo5xUCPpBA";
         let footer = b"";
         let actual =
-            LocalToken::encrypt_with_nonce(&TEST_SK, &TEST_NONCE_2, message, Some(footer)).unwrap();
+            LocalToken::encrypt_with_derived_nonce(&TEST_SK, &TEST_NONCE_2, message, Some(footer))
+                .unwrap();
 
         assert_eq!(expected, actual);
         assert_eq!(
@@ -588,7 +595,8 @@ mod test_local {
         let expected = "v2.local.pvFdDeNtXxknVPsbBCZF6MGedVhPm40SneExdClOxa9HNR8wFv7cu1cB0B4WxDdT6oUc2toyLR6jA6sc-EUM5ll1EkeY47yYk6q8m1RCpqTIzUrIu3B6h232h62DPbIxtjGvNRAwsLK7LcV8oQ";
         let footer = b"";
         let actual =
-            LocalToken::encrypt_with_nonce(&TEST_SK, &TEST_NONCE_2, message, Some(footer)).unwrap();
+            LocalToken::encrypt_with_derived_nonce(&TEST_SK, &TEST_NONCE_2, message, Some(footer))
+                .unwrap();
 
         assert_eq!(expected, actual);
         assert_eq!(
@@ -604,7 +612,8 @@ mod test_local {
         let expected = "v2.local.5K4SCXNhItIhyNuVIZcwrdtaDKiyF81-eWHScuE0idiVqCo72bbjo07W05mqQkhLZdVbxEa5I_u5sgVk1QLkcWEcOSlLHwNpCkvmGGlbCdNExn6Qclw3qTKIIl5-zSLIrxZqOLwcFLYbVK1SrQ.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
         let footer = b"{\"kid\":\"zVhMiPBP9fRf2snEcT7gFTioeA9COcNy9DfgL1W60haN\"}";
         let actual =
-            LocalToken::encrypt_with_nonce(&TEST_SK, &TEST_NONCE_2, message, Some(footer)).unwrap();
+            LocalToken::encrypt_with_derived_nonce(&TEST_SK, &TEST_NONCE_2, message, Some(footer))
+                .unwrap();
 
         assert_eq!(expected, actual);
         assert_eq!(
@@ -620,7 +629,8 @@ mod test_local {
         let expected = "v2.local.pvFdDeNtXxknVPsbBCZF6MGedVhPm40SneExdClOxa9HNR8wFv7cu1cB0B4WxDdT6oUc2toyLR6jA6sc-EUM5ll1EkeY47yYk6q8m1RCpqTIzUrIu3B6h232h62DnMXKdHn_Smp6L_NfaEnZ-A.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
         let footer = b"{\"kid\":\"zVhMiPBP9fRf2snEcT7gFTioeA9COcNy9DfgL1W60haN\"}";
         let actual =
-            LocalToken::encrypt_with_nonce(&TEST_SK, &TEST_NONCE_2, message, Some(footer)).unwrap();
+            LocalToken::encrypt_with_derived_nonce(&TEST_SK, &TEST_NONCE_2, message, Some(footer))
+                .unwrap();
 
         assert_eq!(expected, actual);
         assert_eq!(
@@ -635,9 +645,13 @@ mod test_local {
         let message = b"";
         let expected = "v2.local.driRNhM20GQPvlWfJCepzh6HdijAq-yNUtKpdy5KXjKfpSKrOlqQvQ";
         let footer = b"";
-        let actual =
-            LocalToken::encrypt_with_nonce(&TEST_NULL_KEY, &TEST_NONCE, message, Some(footer))
-                .unwrap();
+        let actual = LocalToken::encrypt_with_derived_nonce(
+            &TEST_NULL_KEY,
+            &TEST_NONCE,
+            message,
+            Some(footer),
+        )
+        .unwrap();
 
         assert_eq!(expected, actual);
         assert_eq!(
@@ -652,9 +666,13 @@ mod test_local {
         let message = b"";
         let expected = "v2.local.driRNhM20GQPvlWfJCepzh6HdijAq-yNSOvpveyCsjPYfe9mtiJDVg";
         let footer = b"";
-        let actual =
-            LocalToken::encrypt_with_nonce(&TEST_FULL_KEY, &TEST_NONCE, message, Some(footer))
-                .unwrap();
+        let actual = LocalToken::encrypt_with_derived_nonce(
+            &TEST_FULL_KEY,
+            &TEST_NONCE,
+            message,
+            Some(footer),
+        )
+        .unwrap();
 
         assert_eq!(expected, actual);
         assert_eq!(
@@ -670,7 +688,8 @@ mod test_local {
         let expected = "v2.local.driRNhM20GQPvlWfJCepzh6HdijAq-yNkIWACdHuLiJiW16f2GuGYA";
         let footer = b"";
         let actual =
-            LocalToken::encrypt_with_nonce(&TEST_SK, &TEST_NONCE, message, Some(footer)).unwrap();
+            LocalToken::encrypt_with_derived_nonce(&TEST_SK, &TEST_NONCE, message, Some(footer))
+                .unwrap();
 
         assert_eq!(expected, actual);
         assert_eq!(
@@ -686,9 +705,13 @@ mod test_local {
         let expected =
             "v2.local.driRNhM20GQPvlWfJCepzh6HdijAq-yNfzz6yGkE4ZxojJAJwKLfvg.Q3VvbiBBbHBpbnVz";
         let footer = b"Cuon Alpinus";
-        let actual =
-            LocalToken::encrypt_with_nonce(&TEST_NULL_KEY, &TEST_NONCE, message, Some(footer))
-                .unwrap();
+        let actual = LocalToken::encrypt_with_derived_nonce(
+            &TEST_NULL_KEY,
+            &TEST_NONCE,
+            message,
+            Some(footer),
+        )
+        .unwrap();
 
         assert_eq!(expected, actual);
         assert_eq!(
@@ -704,9 +727,13 @@ mod test_local {
         let expected =
             "v2.local.driRNhM20GQPvlWfJCepzh6HdijAq-yNJbTJxAGtEg4ZMXY9g2LSoQ.Q3VvbiBBbHBpbnVz";
         let footer = b"Cuon Alpinus";
-        let actual =
-            LocalToken::encrypt_with_nonce(&TEST_FULL_KEY, &TEST_NONCE, message, Some(footer))
-                .unwrap();
+        let actual = LocalToken::encrypt_with_derived_nonce(
+            &TEST_FULL_KEY,
+            &TEST_NONCE,
+            message,
+            Some(footer),
+        )
+        .unwrap();
 
         assert_eq!(expected, actual);
         assert_eq!(
@@ -723,7 +750,8 @@ mod test_local {
             "v2.local.driRNhM20GQPvlWfJCepzh6HdijAq-yNreCcZAS0iGVlzdHjTf2ilg.Q3VvbiBBbHBpbnVz";
         let footer = b"Cuon Alpinus";
         let actual =
-            LocalToken::encrypt_with_nonce(&TEST_SK, &TEST_NONCE, message, Some(footer)).unwrap();
+            LocalToken::encrypt_with_derived_nonce(&TEST_SK, &TEST_NONCE, message, Some(footer))
+                .unwrap();
 
         assert_eq!(expected, actual);
         assert_eq!(
@@ -738,9 +766,13 @@ mod test_local {
         let message = b"Love is stronger than hate or fear";
         let expected = "v2.local.BEsKs5AolRYDb_O-bO-lwHWUextpShFSvu6cB-KuR4wR9uDMjd45cPiOF0zxb7rrtOB5tRcS7dWsFwY4ONEuL5sWeunqHC9jxU0";
         let footer = b"";
-        let actual =
-            LocalToken::encrypt_with_nonce(&TEST_NULL_KEY, &TEST_NONCE, message, Some(footer))
-                .unwrap();
+        let actual = LocalToken::encrypt_with_derived_nonce(
+            &TEST_NULL_KEY,
+            &TEST_NONCE,
+            message,
+            Some(footer),
+        )
+        .unwrap();
 
         assert_eq!(expected, actual);
         assert_eq!(
@@ -755,9 +787,13 @@ mod test_local {
         let message = b"Love is stronger than hate or fear";
         let expected = "v2.local.BEsKs5AolRYDb_O-bO-lwHWUextpShFSjvSia2-chHyMi4LtHA8yFr1V7iZmKBWqzg5geEyNAAaD6xSEfxoET1xXqahe1jqmmPw";
         let footer = b"";
-        let actual =
-            LocalToken::encrypt_with_nonce(&TEST_FULL_KEY, &TEST_NONCE, message, Some(footer))
-                .unwrap();
+        let actual = LocalToken::encrypt_with_derived_nonce(
+            &TEST_FULL_KEY,
+            &TEST_NONCE,
+            message,
+            Some(footer),
+        )
+        .unwrap();
 
         assert_eq!(expected, actual);
         assert_eq!(
@@ -773,7 +809,8 @@ mod test_local {
         let expected = "v2.local.BEsKs5AolRYDb_O-bO-lwHWUextpShFSXlvv8MsrNZs3vTSnGQG4qRM9ezDl880jFwknSA6JARj2qKhDHnlSHx1GSCizfcF019U";
         let footer = b"";
         let actual =
-            LocalToken::encrypt_with_nonce(&TEST_SK, &TEST_NONCE, message, Some(footer)).unwrap();
+            LocalToken::encrypt_with_derived_nonce(&TEST_SK, &TEST_NONCE, message, Some(footer))
+                .unwrap();
 
         assert_eq!(expected, actual);
         assert_eq!(
@@ -788,9 +825,13 @@ mod test_local {
         let message = b"Love is stronger than hate or fear";
         let expected = "v2.local.FGVEQLywggpvH0AzKtLXz0QRmGYuC6yvbcqXgWxM3vJGrJ9kWqquP61Xl7bz4ZEqN5XwH7xyzV0QqPIo0k52q5sWxUQ4LMBFFso.Q3VvbiBBbHBpbnVz";
         let footer = b"Cuon Alpinus";
-        let actual =
-            LocalToken::encrypt_with_nonce(&TEST_NULL_KEY, &TEST_NONCE_2, message, Some(footer))
-                .unwrap();
+        let actual = LocalToken::encrypt_with_derived_nonce(
+            &TEST_NULL_KEY,
+            &TEST_NONCE_2,
+            message,
+            Some(footer),
+        )
+        .unwrap();
 
         assert_eq!(expected, actual);
         assert_eq!(
@@ -805,9 +846,13 @@ mod test_local {
         let message = b"Love is stronger than hate or fear";
         let expected = "v2.local.FGVEQLywggpvH0AzKtLXz0QRmGYuC6yvZMW3MgUMFplQXsxcNlg2RX8LzFxAqj4qa2FwgrUdH4vYAXtCFrlGiLnk-cHHOWSUSaw.Q3VvbiBBbHBpbnVz";
         let footer = b"Cuon Alpinus";
-        let actual =
-            LocalToken::encrypt_with_nonce(&TEST_FULL_KEY, &TEST_NONCE_2, message, Some(footer))
-                .unwrap();
+        let actual = LocalToken::encrypt_with_derived_nonce(
+            &TEST_FULL_KEY,
+            &TEST_NONCE_2,
+            message,
+            Some(footer),
+        )
+        .unwrap();
 
         assert_eq!(expected, actual);
         assert_eq!(
@@ -823,7 +868,8 @@ mod test_local {
         let expected = "v2.local.FGVEQLywggpvH0AzKtLXz0QRmGYuC6yvl05z9GIX0cnol6UK94cfV77AXnShlUcNgpDR12FrQiurS8jxBRmvoIKmeMWC5wY9Y6w.Q3VvbiBBbHBpbnVz";
         let footer = b"Cuon Alpinus";
         let actual =
-            LocalToken::encrypt_with_nonce(&TEST_SK, &TEST_NONCE_2, message, Some(footer)).unwrap();
+            LocalToken::encrypt_with_derived_nonce(&TEST_SK, &TEST_NONCE_2, message, Some(footer))
+                .unwrap();
 
         assert_eq!(expected, actual);
         assert_eq!(
@@ -839,7 +885,8 @@ mod test_local {
         let expected = "v2.local.5K4SCXNhItIhyNuVIZcwrdtaDKiyF81-eWHScuE0idiVqCo72bbjo07W05mqQkhLZdVbxEa5I_u5sgVk1QLkcWEcOSlLHwNpCkvmGGlbCdNExn6Qclw3qTKIIl5-zKeei_8CY0oUMtEai3HYcQ.UGFyYWdvbiBJbml0aWF0aXZlIEVudGVycHJpc2Vz";
         let footer = b"Paragon Initiative Enterprises";
         let actual =
-            LocalToken::encrypt_with_nonce(&TEST_SK, &TEST_NONCE_2, message, Some(footer)).unwrap();
+            LocalToken::encrypt_with_derived_nonce(&TEST_SK, &TEST_NONCE_2, message, Some(footer))
+                .unwrap();
 
         assert_eq!(expected, actual);
         assert_eq!(
@@ -855,7 +902,8 @@ mod test_local {
         let expected = "v2.local.5K4SCXNhItIhyNuVIZcwrdtaDKiyF81-eWHScuE0idiVqCo72bbjo07W05mqQkhLZdVbxEa5I_u5sgVk1QLkcWEcOSlLHwNpCkvmGGlbCdNExn6Qclw3qTKIIl5-zSLIrxZqOLwcFLYbVK1SrQ.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
         let footer = b"{\"kid\":\"zVhMiPBP9fRf2snEcT7gFTioeA9COcNy9DfgL1W60haN\"}";
         let actual =
-            LocalToken::encrypt_with_nonce(&TEST_SK, &TEST_NONCE_2, message, Some(footer)).unwrap();
+            LocalToken::encrypt_with_derived_nonce(&TEST_SK, &TEST_NONCE_2, message, Some(footer))
+                .unwrap();
 
         assert_eq!(expected, actual);
         assert_eq!(

--- a/src/version2.rs
+++ b/src/version2.rs
@@ -484,9 +484,6 @@ mod test_local {
 
     #[test]
     fn invalid_secret_key() {
-        use rand::rngs::OsRng;
-        let mut csprng = OsRng {};
-
         let message =
             b"{\"data\":\"this is a signed message\",\"exp\":\"2019-01-01T00:00:00+00:00\"}";
         let expected = "v2.local.97TTOvgwIxNGvV80XKiGZg_kD3tsXM_-qB4dZGHOeN1cTkgQ4PnW8888l802W8d9AvEGnoNBY3BnqHORy8a5cC8aKpbA0En8XELw2yDk2f1sVODyfnDbi6rEGMY3pSfCbLWMM2oHJxvlEl2XbQ";
@@ -505,9 +502,6 @@ mod test_local {
 
     #[test]
     fn encrypt_decrypt_roundtrip() {
-        use rand::rngs::OsRng;
-        let mut csprng = OsRng {};
-
         let message = b"Hello, World!";
         let footer = b"";
         let token = LocalToken::encrypt(&TEST_SK, message, Some(footer)).unwrap();

--- a/src/version2.rs
+++ b/src/version2.rs
@@ -8,15 +8,17 @@ use crate::pae;
 use ct_codecs::{Base64UrlSafeNoPadding, Decoder, Encoder};
 use rand_core::{CryptoRng, RngCore};
 
-fn encode_b64<T: AsRef<[u8]>>(encoded: T) -> Result<String, Errors> {
-    let inlen = encoded.as_ref().len();
+/// Encode bytes with Base64 URL-safe and no padding.
+fn encode_b64<T: AsRef<[u8]>>(bytes: T) -> Result<String, Errors> {
+    let inlen = bytes.as_ref().len();
     let mut buf = vec![0u8; Base64UrlSafeNoPadding::encoded_len(inlen)?];
 
-    let ret: String = Base64UrlSafeNoPadding::encode_to_str(&mut buf, encoded)?.into();
+    let ret: String = Base64UrlSafeNoPadding::encode_to_str(&mut buf, bytes)?.into();
 
     Ok(ret)
 }
 
+/// Decode string with Base64 URL-safe and no padding.
 fn decode_b64<T: AsRef<[u8]>>(encoded: T) -> Result<Vec<u8>, Errors> {
     let inlen = encoded.as_ref().len();
     // We can use encoded len here, even if it returns more than needed,


### PR DESCRIPTION
-  Remove `Csprng` trait from public API and use `getrandom` instead
- Update Orion to `0.16`

TODO:
- [X] Remove the `ignore` of `rand_core` in `dependabot.yml` (the affected parts of the library from the advisory are not used in this crate)

See also https://github.com/dalek-cryptography/ed25519-dalek/issues/162 as part of the motivation behind this.