### PR TITLE
Claims and their validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ __Changelog:__
 - New `SymmetricKey`, `AsymmetricPublicKey` and `AsymmetricSecretKey` now used throughout the API of both version 2 and 4 ([#14](https://github.com/brycx/pasetors/issues/14))
 - Use new test vectors from https://github.com/paseto-standard/test-vectors
 - Empty payloads are no longer allowed (see https://github.com/paseto-standard/paseto-spec/issues/17) and `Errors::EmptyPayloadError` has been added
+- New `Claims` type to easily define claims for tokens and `ClaimsValidationRules` to validate such claims.
 
 ### 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ __Changelog:__
 - Use new test vectors from https://github.com/paseto-standard/test-vectors
 - Empty payloads are no longer allowed (see https://github.com/paseto-standard/paseto-spec/issues/17) and `Errors::EmptyPayloadError` has been added
 - New `Claims` type to easily define claims for tokens and `ClaimsValidationRules` to validate such claims.
+- New `std` feature which is enabled by default. This means, that to be `no_std`, `pasetors` has to be declared without default features.
 
 ### 0.2.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,15 @@ default-features = false
 [dependencies.zeroize]
 version = "1.4.1"
 default-features = false
+
+[dependencies.serde_json]
+version = "1.0.41"
+optional = true
+
+[dependencies.chrono]
+version = "0.4"
+optional = true
+
+[features]
+default = [ "std" ]
+std = [ "serde_json", "chrono" ]

--- a/README.md
+++ b/README.md
@@ -8,32 +8,14 @@ PASETO (Platform-Agnostic SEcurity TOkens) are secure stateless tokens. Read mor
 
 This library includes:
 - [x] Pure-Rust implementation of the Version 4 and 2 protocol
-- [x] `#![no_std]` and `#![forbid(unsafe_code)]`
+- [x] `#![no_std]` (with default-features disabled) and `#![forbid(unsafe_code)]`
 - [x] Fuzzing targets
 - [x] Test vectors
 - [x] Usage examples
 
 ### Usage
-```rust
-use pasetors::version4::*;
-use pasetors::keys::*;
-use ed25519_dalek::Keypair;
 
-let mut csprng = rand::rngs::OsRng{};
-
-// Create and verify a public token
-let keypair: Keypair = Keypair::generate(&mut csprng);
-let sk = AsymmetricSecretKey::from(&keypair.secret.to_bytes(), Version::V4)?;
-let pk = AsymmetricPublicKey::from(&keypair.public.to_bytes(), Version::V4)?;
-let pub_token = PublicToken::sign(&sk, &pk, b"Message to sign", Some(b"footer"), Some(b"implicit assertion"))?;
-assert!(PublicToken::verify(&pk, &pub_token, Some(b"footer"), Some(b"implicit assertion")).is_ok());
-
-// Create and verify a local token
-let sk = SymmetricKey::gen(Version::V4)?;
-
-let local_token = LocalToken::encrypt(&sk, b"Message to encrypt and authenticate", Some(b"footer"), Some(b"implicit assertion"))?;
-assert!(LocalToken::decrypt(&sk, &local_token, Some(b"footer"), Some(b"implicit assertion")).is_ok());
-```
+[See usage examples here](https://docs.rs/pasetors/).
 
 ### Security
 

--- a/fuzz/fuzz_targets/fuzz_pasetors.rs
+++ b/fuzz/fuzz_targets/fuzz_pasetors.rs
@@ -91,13 +91,17 @@ fn fuzz_highlevel(data: &[u8], csprng: &mut ChaCha20Rng) {
 
     let public_token =
         pasetors::public::sign(&sk, &pk, &claims, None, None).unwrap();
-    if !pasetors::public::verify(&pk, &public_token, &validation_rules, None, None).is_ok() {
+    if let Ok(claims_from) = pasetors::public::verify(&pk, &public_token, &validation_rules, None, None) {
+        assert_eq!(claims, claims_from);
+    } else {
         panic!("Valid token was NOT verified with version 4");
     }
 
     let local_token =
         pasetors::local::encrypt(&sk_local,&claims, None, None).unwrap();
-    if !pasetors::local::decrypt(&sk_local, &local_token, &validation_rules, None, None).is_ok() {
+    if let Ok(claims_from) = pasetors::local::decrypt(&sk_local, &local_token, &validation_rules, None, None) {
+        assert_eq!(claims, claims_from);
+    } else {
         panic!("Valid token was NOT verified with version 4");
     }
 }

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -268,7 +268,7 @@ impl ClaimsValidationRules {
     /// - The claims values cannot be converted to `str`
     /// - `iat`, `nbf` and `exp` fail `str -> DateTime` conversion
     ///
-    /// NOTE: This does not validate any non-registered claims. They must be validated
+    /// NOTE: This __does not__ validate any non-registered claims (see [`Claims::REGISTERED_CLAIMS`]). They must be validated
     /// separately.
     pub fn validate_claims(&self, claims: &Claims) -> Result<(), Errors> {
         if self.validate_currently_valid {

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -458,7 +458,6 @@ mod test {
 
     #[test]
     fn test_invalid_token_at_time() {
-        // Set all claims plus a custom one
         let claims = Claims::new().unwrap();
         let claims_validation = ClaimsValidationRules::new();
 

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -1,0 +1,348 @@
+use crate::errors::Errors;
+use chrono::prelude::*;
+use chrono::Duration;
+use std::collections::HashMap;
+
+#[derive(Debug, PartialEq)]
+/// A collection of claims that are passed as payload for a PASETO token.
+pub struct Claims {
+    list_of: HashMap<String, String>,
+}
+
+impl Claims {
+    /// Keys for registered claims, that are reserved for usage by PASETO in top-level.
+    pub const REGISTERED_CLAIMS: [&'static str; 7] =
+        ["iss", "sub", "aud", "exp", "nbf", "iat", "jti"];
+
+    /// Create a new `Claims` instance, setting:
+    /// - `iat`, `nbf` to current UTC time
+    /// - `exp` to one hour
+    ///
+    /// Errors:
+    /// - If adding current time with one hour would overflow
+    pub fn new() -> Result<Self, Errors> {
+        let iat = Utc::now();
+        let nbf = iat;
+        let exp = match iat.checked_add_signed(Duration::hours(1)) {
+            Some(value) => value,
+            None => return Err(Errors::InvalidClaimError),
+        };
+
+        let mut claims = Self {
+            list_of: HashMap::new(),
+        };
+
+        claims.issued_at(&iat.to_string())?;
+        claims.not_before(&nbf.to_string())?;
+        claims.expiration(&exp.to_string())?;
+
+        Ok(claims)
+    }
+
+    /// Add additional claims. If `claim` already exists, it is replaced with the new.
+    ///
+    /// Errors:
+    /// - `claim` is a reserved claim (see [`Self::REGISTERED_CLAIMS`])
+    pub fn add_additional(&mut self, claim: &str, value: &str) -> Result<(), Errors> {
+        if !Self::REGISTERED_CLAIMS.contains(&claim) {
+            self.list_of.insert(claim.into(), value.into());
+            Ok(())
+        } else {
+            Err(Errors::InvalidClaimError)
+        }
+    }
+
+    /// Checks whether a specific claim has been added to the list.
+    ///
+    /// E.g `contains_claim("iss") == true` if `iss` has been added before.
+    pub fn contains_claim(&self, claim: &str) -> bool {
+        self.list_of.contains_key(claim)
+    }
+
+    /// Set the `iss` claim. If it already exists, replace it with the new.
+    ///
+    /// Errors:
+    /// - `iss` is empty
+    pub fn issuer(&mut self, iss: &str) -> Result<(), Errors> {
+        if !iss.is_empty() {
+            self.list_of.insert("iss".into(), iss.into());
+            Ok(())
+        } else {
+            Err(Errors::InvalidClaimError)
+        }
+    }
+
+    /// Set the `sub` claim. If it already exists, replace it with the new.
+    ///
+    /// Errors:
+    /// - `sub` is empty
+    pub fn subject(&mut self, sub: &str) -> Result<(), Errors> {
+        if !sub.is_empty() {
+            self.list_of.insert("sub".into(), sub.into());
+            Ok(())
+        } else {
+            Err(Errors::InvalidClaimError)
+        }
+    }
+
+    /// Set the `aud` claim. If it already exists, replace it with the new.
+    ///
+    /// Errors:
+    /// - `aud` is empty
+    pub fn audience(&mut self, aud: &str) -> Result<(), Errors> {
+        if !aud.is_empty() {
+            self.list_of.insert("aud".into(), aud.into());
+            Ok(())
+        } else {
+            Err(Errors::InvalidClaimError)
+        }
+    }
+
+    /// Set the `exp` claim. If it already exists, replace it with the new.
+    ///
+    /// Errors:
+    /// - `exp` is empty
+    /// - `exp` cannot be parsed as a ISO 8601 compliant DateTime string.
+    pub fn expiration(&mut self, exp: &str) -> Result<(), Errors> {
+        if exp.parse::<DateTime<Utc>>().is_ok() {
+            self.list_of.insert("exp".into(), exp.into());
+            Ok(())
+        } else {
+            Err(Errors::InvalidClaimError)
+        }
+    }
+
+    /// Set the `nbf` claim. If it already exists, replace it with the new.
+    ///
+    /// Errors:
+    /// - `nbf` is empty
+    /// - `nbf` cannot be parsed as a ISO 8601 compliant DateTime string.
+    pub fn not_before(&mut self, nbf: &str) -> Result<(), Errors> {
+        if nbf.parse::<DateTime<Utc>>().is_ok() {
+            self.list_of.insert("nbf".into(), nbf.into());
+            Ok(())
+        } else {
+            Err(Errors::InvalidClaimError)
+        }
+    }
+
+    /// Set the `iat` claim. If it already exists, replace it with the new.
+    ///
+    /// Errors:
+    /// - `iat` is empty
+    /// - `iat` cannot be parsed as a ISO 8601 compliant DateTime string.
+    pub fn issued_at(&mut self, iat: &str) -> Result<(), Errors> {
+        if iat.parse::<DateTime<Utc>>().is_ok() {
+            self.list_of.insert("iat".into(), iat.into());
+            Ok(())
+        } else {
+            Err(Errors::InvalidClaimError)
+        }
+    }
+
+    /// Set the `jti` claim. If it already exists, replace it with the new.
+    ///
+    /// Errors:
+    /// - `jti` is empty
+    pub fn token_identifier(&mut self, jti: &str) -> Result<(), Errors> {
+        if !jti.is_empty() {
+            self.list_of.insert("jti".into(), jti.into());
+            Ok(())
+        } else {
+            Err(Errors::InvalidClaimError)
+        }
+    }
+}
+
+/// The validation rules that are used to validate a set of claims.
+pub struct ClaimsValidationRules {
+    // TODO: How to allow validating for non-expiring tokens.
+    validate_currently_valid: bool,
+    validate_issuer: Option<String>,
+    validate_subject: Option<String>,
+    validate_audience: Option<String>,
+    validate_token_identifier: Option<String>,
+}
+
+impl Default for ClaimsValidationRules {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ClaimsValidationRules {
+    /// Create a new `ClaimsValidationRules` instance, setting:
+    /// - validation of `iat`, `nbf`, `exp` true
+    pub fn new() -> Self {
+        Self {
+            validate_currently_valid: true,
+            validate_issuer: None,
+            validate_subject: None,
+            validate_audience: None,
+            validate_token_identifier: None,
+        }
+    }
+
+    /// Set the `valid_issuer` the claims should be validated against.
+    pub fn validate_issuer(&mut self, valid_issuer: &str) {
+        self.validate_issuer = Some(valid_issuer.to_string());
+    }
+
+    /// Set the `valid_subject` the claims should be validated against.
+    pub fn validate_subject(&mut self, valid_subject: &str) {
+        self.validate_subject = Some(valid_subject.to_string());
+    }
+
+    /// Set the `valid_audience` the claims should be validated against.
+    pub fn validate_audience(&mut self, valid_audience: &str) {
+        self.validate_audience = Some(valid_audience.to_string());
+    }
+
+    /// Set the `valid_token_identifier` the claims should be validated against.
+    pub fn validate_token_identifier(&mut self, valid_token_identifier: &str) {
+        self.validate_token_identifier = Some(valid_token_identifier.to_string());
+    }
+
+    /// Validate the set of `claims` against the currently defined validation rules.
+    pub fn validate_claims(&self, claims: &Claims) -> Result<(), Errors> {
+        if self.validate_currently_valid {
+            match (
+                claims.list_of.get("iat"),
+                claims.list_of.get("nbf"),
+                claims.list_of.get("exp"),
+            ) {
+                (Some(iat), Some(nbf), Some(exp)) => {
+                    let iat = iat
+                        .parse::<DateTime<Utc>>()
+                        .map_err(|_| Errors::ClaimValidationError)?;
+                    let nbf = nbf
+                        .parse::<DateTime<Utc>>()
+                        .map_err(|_| Errors::ClaimValidationError)?;
+                    let exp = exp
+                        .parse::<DateTime<Utc>>()
+                        .map_err(|_| Errors::ClaimValidationError)?;
+                    let current_time = Utc::now();
+
+                    if current_time > exp || current_time < nbf || current_time < iat {
+                        return Err(Errors::ClaimValidationError);
+                    }
+                }
+                _ => return Err(Errors::ClaimValidationError),
+            }
+        }
+
+        if let Some(expected_issuer) = &self.validate_issuer {
+            if let Some(actual_issuer) = claims.list_of.get("iss") {
+                if expected_issuer != actual_issuer {
+                    return Err(Errors::ClaimValidationError);
+                }
+            } else {
+                return Err(Errors::ClaimValidationError);
+            }
+        }
+
+        if let Some(expected_subject) = &self.validate_subject {
+            if let Some(actual_subject) = claims.list_of.get("sub") {
+                if expected_subject != actual_subject {
+                    return Err(Errors::ClaimValidationError);
+                }
+            } else {
+                return Err(Errors::ClaimValidationError);
+            }
+        }
+
+        if let Some(expected_audience) = &self.validate_audience {
+            if let Some(actual_audience) = claims.list_of.get("aud") {
+                if expected_audience != actual_audience {
+                    return Err(Errors::ClaimValidationError);
+                }
+            } else {
+                return Err(Errors::ClaimValidationError);
+            }
+        }
+
+        if let Some(expected_token_identifier) = &self.validate_token_identifier {
+            if let Some(actual_token_identifier) = claims.list_of.get("jti") {
+                if expected_token_identifier != actual_token_identifier {
+                    return Err(Errors::ClaimValidationError);
+                }
+            } else {
+                return Err(Errors::ClaimValidationError);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_empty_claim_value() {
+        let mut claims = Claims::new().unwrap();
+
+        assert!(claims.issuer("").is_err());
+        assert!(claims.subject("").is_err());
+        assert!(claims.audience("").is_err());
+        assert!(claims.expiration("").is_err());
+        assert!(claims.not_before("").is_err());
+        assert!(claims.issued_at("").is_err());
+        assert!(claims.token_identifier("").is_err());
+    }
+
+    #[test]
+    fn test_error_on_arbitrary_registered() {
+        let mut claims = Claims::new().unwrap();
+
+        assert!(claims.add_additional("iss", "test").is_err());
+        assert!(claims.add_additional("sub", "test").is_err());
+        assert!(claims.add_additional("aud", "test").is_err());
+        assert!(claims
+            .add_additional("exp", "2014-11-28T21:00:09+09:00")
+            .is_err());
+        assert!(claims
+            .add_additional("nbf", "2014-11-28T21:00:09+09:00")
+            .is_err());
+        assert!(claims
+            .add_additional("iat", "2014-11-28T21:00:09+09:00")
+            .is_err());
+        assert!(claims.add_additional("jti", "test").is_err());
+
+        assert!(claims.add_additional("not_reserved", "test").is_ok());
+    }
+
+    #[test]
+    fn test_failed_datetime_parsing() {
+        let mut claims = Claims::new().unwrap();
+
+        assert!(claims
+            .expiration("this is not a ISO 8601 DateTime string")
+            .is_err());
+        assert!(claims
+            .not_before("this is not a ISO 8601 DateTime string")
+            .is_err());
+        assert!(claims
+            .issued_at("this is not a ISO 8601 DateTime string")
+            .is_err());
+    }
+
+    #[test]
+    fn test_contains_claim() {
+        let mut claims = Claims::new().unwrap();
+
+        // Default claims
+        assert_eq!(claims.contains_claim("iat"), true);
+        assert_eq!(claims.contains_claim("nbf"), true);
+        assert_eq!(claims.contains_claim("exp"), true);
+
+        assert_eq!(claims.contains_claim("iss"), false);
+        claims.issuer("testIssuer").unwrap();
+        assert_eq!(claims.contains_claim("iss"), true);
+
+        assert_eq!(claims.contains_claim("aud"), false);
+        claims.audience("testAudience").unwrap();
+        assert_eq!(claims.contains_claim("aud"), true);
+    }
+}

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -67,6 +67,12 @@ impl Claims {
         self.list_of.contains_key(claim)
     }
 
+    /// Return Some(claim value) if claims list contains the `claim`.
+    /// None otherwise.
+    pub fn get_claim(&self, claim: &str) -> Option<&Value> {
+        self.list_of.get(claim)
+    }
+
     /// Set the `iss` claim. If it already exists, replace it with the new.
     ///
     /// Errors:

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -170,7 +170,7 @@ impl Claims {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Errors> {
         let input = bytes.to_vec();
 
-        Self::from_str(&String::from_utf8(input).map_err(|_| Errors::ClaimInvalidUtf8)?)
+        Self::from_string(&String::from_utf8(input).map_err(|_| Errors::ClaimInvalidUtf8)?)
     }
 
     /// Attempt to create `Claims` from a string.
@@ -178,7 +178,7 @@ impl Claims {
     /// Errors:
     /// - `string` does not decode as valid JSON
     /// - `string` top-most JSON object does not decode to a map
-    pub fn from_str(string: &str) -> Result<Self, Errors> {
+    pub fn from_string(string: &str) -> Result<Self, Errors> {
         let list_of: HashMap<String, Value> =
             serde_json::from_str(string).map_err(|_| Errors::ClaimInvalidJson)?;
 
@@ -189,7 +189,7 @@ impl Claims {
     ///
     /// Errors:
     /// - `self` cannot be serialized as JSON
-    pub fn to_str(&self) -> Result<String, Errors> {
+    pub fn to_string(&self) -> Result<String, Errors> {
         match serde_json::to_string(&self.list_of) {
             Ok(ret) => Ok(ret),
             Err(_) => Err(Errors::ClaimInvalidJson),
@@ -300,11 +300,9 @@ impl ClaimsValidationRules {
             } else {
                 return Err(Errors::ClaimValidationError);
             }
-        } else {
-            if !self.allow_non_expiring {
-                // We didn't explicitly allow non-expiring tokens so we expect `exp` claim.
-                return Err(Errors::ClaimValidationError);
-            }
+        } else if !self.allow_non_expiring {
+            // We didn't explicitly allow non-expiring tokens so we expect `exp` claim.
+            return Err(Errors::ClaimValidationError);
         }
 
         if let Some(expected_issuer) = &self.validate_issuer {
@@ -631,8 +629,8 @@ mod test {
         claims.add_additional("two", add_claims_two).unwrap();
         claims.add_additional("three", add_claims_three).unwrap();
 
-        let as_string = claims.to_str().unwrap();
-        let from_converted = Claims::from_str(&as_string).unwrap();
+        let as_string = claims.to_string().unwrap();
+        let from_converted = Claims::from_string(&as_string).unwrap();
         assert_eq!(from_converted, claims);
 
         assert!(claims.contains_claim("one"));

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -40,8 +40,6 @@ impl Claims {
         Ok(claims)
     }
 
-    /// TODO: If a user want to add anything but a string to additional claims,
-    /// they have to encode it themselves beforehand, but that seems like a bad approach.
     /// Add additional claims. If `claim` already exists, it is replaced with the new.
     ///
     /// Errors:

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -268,7 +268,7 @@ impl ClaimsValidationRules {
         if self.validate_currently_valid {
             match (claims.list_of.get("iat"), claims.list_of.get("nbf")) {
                 (Some(iat), Some(nbf)) => match (iat.as_str(), nbf.as_str()) {
-                    (Some(iat), Some(nbf), Some(exp)) => {
+                    (Some(iat), Some(nbf)) => {
                         let iat = iat
                             .parse::<DateTime<Utc>>()
                             .map_err(|_| Errors::ClaimValidationError)?;
@@ -638,5 +638,18 @@ mod test {
         assert!(claims.contains_claim("one"));
         assert!(claims.contains_claim("two"));
         assert!(claims.contains_claim("three"));
+    }
+
+    #[test]
+    fn test_token_no_expiration() {
+        let mut claims = Claims::new().unwrap();
+        let mut claims_validation = ClaimsValidationRules::new();
+
+        claims.non_expiring();
+        // Claims validation is not explicitly set to allow non-expiring, so we get error here
+        // because claims is missing exp
+        assert!(claims_validation.validate_claims(&claims).is_err());
+        claims_validation.allow_non_expiring();
+        assert!(claims_validation.validate_claims(&claims).is_ok());
     }
 }

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -40,6 +40,13 @@ impl Claims {
         Ok(claims)
     }
 
+    /// Removes the `exp` claim, indicating a token that never expires.
+    pub fn non_expiring(&mut self) {
+        if self.contains_claim("exp") {
+            self.list_of.remove_entry("exp").unwrap();
+        }
+    }
+
     /// Add additional claims. If `claim` already exists, it is replaced with the new.
     ///
     /// Errors:
@@ -240,6 +247,11 @@ impl ClaimsValidationRules {
     }
 
     /// Validate the set of `claims` against the currently defined validation rules.
+    ///
+    /// Validates that the token is:
+    /// - currently valid with `iat` <= current time
+    /// - currently valid with `nbf` <= current time
+    /// - currently valid with `exp` > current time
     ///
     /// NOTE: This does not validate any non-registered claims. They must be validated
     /// separately.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,6 +23,10 @@ pub enum Errors {
     /// the expected claim did not match the actual, the token is not valid yet, has
     /// expired or DateTime parsing has failed.
     ClaimValidationError,
+    /// Error for attempting to parse a Claim but found invalid UTF-8 sequence.
+    ClaimInvalidUtf8,
+    /// Error for attempting to parse a Claim but found invalid JSON sequence.
+    ClaimInvalidJson,
 }
 
 impl From<ct_codecs::Error> for Errors {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -19,9 +19,7 @@ pub enum Errors {
     EmptyPayloadError,
     /// Error for attempting to create an invalid claim.
     InvalidClaimError,
-    /// Claim validation error. Either, a claim was expected but not present,
-    /// the expected claim did not match the actual, the token is not valid yet, has
-    /// expired or DateTime parsing has failed.
+    /// Claim validation error. See [`crate::claims::ClaimsValidationRules::validate_claims`].
     ClaimValidationError,
     /// Error for attempting to parse a Claim but found invalid UTF-8 sequence.
     ClaimInvalidUtf8,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,6 +17,12 @@ pub enum Errors {
     LossyConversionError,
     /// Error for attempting to create a token with an empty payload.
     EmptyPayloadError,
+    /// Error for attempting to create an invalid claim.
+    InvalidClaimError,
+    /// Claim validation error. Either, a claim was expected but not present,
+    /// the expected claim did not match the actual, the token is not valid yet, has
+    /// expired or DateTime parsing has failed.
+    ClaimValidationError,
 }
 
 impl From<ct_codecs::Error> for Errors {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -91,7 +91,7 @@ impl Drop for AsymmetricSecretKey {
 }
 
 impl AsymmetricSecretKey {
-    /// Create a `AsymmetricSecretKey` from `bytes`, to be used with `version`.
+    /// Create an `AsymmetricSecretKey` from `bytes`, to be used with `version`.
     pub fn from(bytes: &[u8], version: Version) -> Result<Self, Errors> {
         if version == Version::V2 || version == Version::V4 {
             if bytes.len() != ed25519_dalek::SECRET_KEY_LENGTH {
@@ -121,7 +121,7 @@ pub struct AsymmetricPublicKey {
 }
 
 impl AsymmetricPublicKey {
-    /// Create a `AsymmetricPublicKey` from `bytes`, to be used with `version`.
+    /// Create an `AsymmetricPublicKey` from `bytes`, to be used with `version`.
     pub fn from(bytes: &[u8], version: Version) -> Result<Self, Errors> {
         if version == Version::V2 || version == Version::V4 {
             if bytes.len() != ed25519_dalek::PUBLIC_KEY_LENGTH {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! # Ok::<(), pasetors::errors::Errors>(())
 //! ```
 
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![forbid(unsafe_code)]
 #![deny(clippy::mem_forget)]
 #![warn(
@@ -44,6 +44,8 @@ pub mod errors;
 
 mod common;
 
+/// Claims for tokens and validation thereof.
+pub mod claims;
 /// Keys used for PASETO tokens.
 pub mod keys;
 /// PASETO version 2 tokens.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@
     unused_qualifications,
     overflowing_literals
 )]
-#![doc(html_root_url = "https://docs.rs/pasetors/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/pasetors/0.3.0")]
 
 #[macro_use]
 extern crate alloc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,3 +52,83 @@ pub mod keys;
 pub mod version2;
 /// PASETO version 4 tokens.
 pub mod version4;
+
+/// PASETO public tokens using `Claims`.
+pub mod public {
+    use crate::claims::{Claims, ClaimsValidationRules};
+    use crate::errors::Errors;
+    use crate::keys::{AsymmetricPublicKey, AsymmetricSecretKey};
+
+    /// Create a public token using the latest PASETO version (v4).
+    pub fn sign(
+        secret_key: &AsymmetricSecretKey,
+        public_key: &AsymmetricPublicKey,
+        message: &Claims,
+        footer: Option<&[u8]>,
+        implicit_assert: Option<&[u8]>,
+    ) -> Result<String, Errors> {
+        crate::version4::PublicToken::sign(
+            secret_key,
+            public_key,
+            message.to_string().unwrap().as_bytes(),
+            footer,
+            implicit_assert,
+        )
+    }
+
+    /// Verify a public token using the latest PASETO version (v4). If verification passes, validate the claims according to the
+    /// `validation_rules`.
+    pub fn verify(
+        public_key: &AsymmetricPublicKey,
+        token: &str,
+        validation_rules: &ClaimsValidationRules,
+        footer: Option<&[u8]>,
+        implicit_assert: Option<&[u8]>,
+    ) -> Result<Claims, Errors> {
+        crate::version4::PublicToken::verify(public_key, token, footer, implicit_assert)?;
+
+        let claims = Claims::from_string(token)?;
+        validation_rules.validate_claims(&claims)?;
+
+        Ok(claims)
+    }
+}
+
+/// PASETO local tokens using `Claims`.
+pub mod local {
+    use crate::claims::{Claims, ClaimsValidationRules};
+    use crate::errors::Errors;
+    use crate::keys::SymmetricKey;
+
+    /// Create a local token using the latest PASETO version (v4).
+    pub fn encrypt(
+        secret_key: &SymmetricKey,
+        message: &Claims,
+        footer: Option<&[u8]>,
+        implicit_assert: Option<&[u8]>,
+    ) -> Result<String, Errors> {
+        crate::version4::LocalToken::encrypt(
+            secret_key,
+            message.to_string().unwrap().as_bytes(),
+            footer,
+            implicit_assert,
+        )
+    }
+
+    /// Verify a local token using the latest PASETO version (v4). If verification passes, validate the claims according to the
+    /// `validation_rules`.
+    pub fn decrypt(
+        secret_key: &SymmetricKey,
+        token: &str,
+        validation_rules: &ClaimsValidationRules,
+        footer: Option<&[u8]>,
+        implicit_assert: Option<&[u8]>,
+    ) -> Result<Claims, Errors> {
+        let raw_payload =
+            crate::version4::LocalToken::decrypt(secret_key, token, footer, implicit_assert)?;
+        let claims = Claims::from_bytes(&raw_payload)?;
+        validation_rules.validate_claims(&claims)?;
+
+        Ok(claims)
+    }
+}


### PR DESCRIPTION
closes #17 

TODO: 

- [X] Add possibility to specify never-expiring tokens in validation
- [X] Decide in approach for handling values of additional claims, which right now are `String`s but should be able to handle things such as `Vec<T>` as well
- [X] lib-module-level API that uses V4 and takes/returns `Claims` and `ClaimsValidationRules`.