### PR TITLE
Implement std::error::Error for Errors

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -27,6 +27,16 @@ pub enum Errors {
     ClaimInvalidJson,
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for Errors {}
+
+#[cfg(feature = "std")]
+impl std::fmt::Display for Errors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("{:?}", self))
+    }
+}
+
 impl From<ct_codecs::Error> for Errors {
     fn from(_: ct_codecs::Error) -> Self {
         Errors::Base64DecodingError


### PR DESCRIPTION
This is handy because it for example makes the `Errors` type usable with `anyhow`/`thiserror`.

Implementing `std::error::Error` for error types [is best practice](https://rust-lang.github.io/api-guidelines/interoperability.html#error-types-are-meaningful-and-well-behaved-c-good-err).

Sidenote: I think it's weird that the enum is named in plural.