### PR TITLE
Add `UntrustedToken` and `TrustedToken`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ __Changelog:__
 - Stricter permissions for GH Actions workflows ([#43](https://github.com/brycx/pasetors/pull/43))
 - Add `Generate` trait and implement this for all key-types, removing also `SymmetricKey::gen()` ([#45](https://github.com/brycx/pasetors/issues/45))
 - Switch from `ed25519-dalek` to `ed25519-compact` ([#48](https://github.com/brycx/pasetors/issues/48))
+- Add new types `token::UntrustedToken` and `token::TrustedToken` which are now used by `verify()`/`decrypt()` operations. 
+These allow extracting parts of tokens before and after verification ([#47](https://github.com/brycx/pasetors/issues/47)) 
+- Version structs previously available in `keys::` have been moved to a new `version::` module
 
 ### 0.4.2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pasetors"
-version = "0.5.0-alpha.3" # Update html_root_url in lib.rs along with this.
+version = "0.5.0-alpha.4" # Update html_root_url in lib.rs along with this.
 authors = ["brycx <brycx@protonmail.com>"]
 edition = "2018"
 description = "PASETO: Platform-Agnostic Security Tokens (in Rust)"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -34,3 +34,15 @@ name = "fuzz_point_comp"
 path = "fuzz_targets/fuzz_point_comp.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "fuzz_types"
+path = "fuzz_targets/fuzz_types.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_paserk"
+path = "fuzz_targets/fuzz_paserk.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_paserk.rs
+++ b/fuzz/fuzz_targets/fuzz_paserk.rs
@@ -1,0 +1,63 @@
+#![no_main]
+extern crate pasetors;
+
+use core::convert::TryFrom;
+use libfuzzer_sys::fuzz_target;
+use pasetors::keys::*;
+use pasetors::paserk::{FormatAsPaserk, Id};
+use pasetors::{V2, V3, V4};
+
+fuzz_target!(|data: &[u8]| {
+    let data: String = String::from_utf8_lossy(data).into();
+
+    if let Ok(valid_paserk) = AsymmetricKeyPair::<V2>::try_from(data.clone()) {
+        let mut buf = String::new();
+        valid_paserk.fmt(&mut buf).unwrap();
+        assert_eq!(&data, &buf);
+        let _ = Id::from(&valid_paserk);
+    }
+    if let Ok(valid_paserk) = AsymmetricSecretKey::<V3>::try_from(data.clone()) {
+        let mut buf = String::new();
+        valid_paserk.fmt(&mut buf).unwrap();
+        assert_eq!(&data, &buf);
+        let _ = Id::from(&valid_paserk);
+    }
+    if let Ok(valid_paserk) = AsymmetricKeyPair::<V4>::try_from(data.clone()) {
+        let mut buf = String::new();
+        valid_paserk.fmt(&mut buf).unwrap();
+        assert_eq!(&data, &buf);
+        let _ = Id::from(&valid_paserk);
+    }
+
+    if let Ok(valid_paserk) = AsymmetricPublicKey::<V2>::try_from(data.clone()) {
+        let mut buf = String::new();
+        valid_paserk.fmt(&mut buf).unwrap();
+        assert_eq!(&data, &buf);
+        let _ = Id::from(&valid_paserk);
+    }
+    if let Ok(valid_paserk) = AsymmetricPublicKey::<V3>::try_from(data.clone()) {
+        let mut buf = String::new();
+        valid_paserk.fmt(&mut buf).unwrap();
+        assert_eq!(&data, &buf);
+        let _ = Id::from(&valid_paserk);
+    }
+    if let Ok(valid_paserk) = AsymmetricPublicKey::<V4>::try_from(data.clone()) {
+        let mut buf = String::new();
+        valid_paserk.fmt(&mut buf).unwrap();
+        assert_eq!(&data, &buf);
+        let _ = Id::from(&valid_paserk);
+    }
+
+    if let Ok(valid_paserk) = SymmetricKey::<V2>::try_from(data.clone()) {
+        let mut buf = String::new();
+        valid_paserk.fmt(&mut buf).unwrap();
+        assert_eq!(&data, &buf);
+        let _ = Id::from(&valid_paserk);
+    }
+    if let Ok(valid_paserk) = SymmetricKey::<V4>::try_from(data.clone()) {
+        let mut buf = String::new();
+        valid_paserk.fmt(&mut buf).unwrap();
+        assert_eq!(&data, &buf);
+        let _ = Id::from(&valid_paserk);
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_pasetors.rs
+++ b/fuzz/fuzz_targets/fuzz_pasetors.rs
@@ -12,7 +12,7 @@ use pasetors::claims::*;
 use pasetors::keys::*;
 use pasetors::token::UntrustedToken;
 use pasetors::{version2, version3, version4};
-use pasetors::{V2, V3, V4};
+use pasetors::{Local, Public, V2, V3, V4};
 use rand_chacha::ChaCha20Rng;
 use rand_core::{RngCore, SeedableRng};
 
@@ -32,13 +32,13 @@ fn fuzztest_v2(data: &[u8], csprng: &mut ChaCha20Rng) {
     }
 
     // Public
-    if let Ok(untrusted) = UntrustedToken::<V2>::try_from(&message) {
+    if let Ok(untrusted) = UntrustedToken::<Public, V2>::try_from(&message) {
         if version2::PublicToken::verify(&pk, &untrusted, None).is_ok() {
             panic!("Invalid token was verified with version 2");
         }
     }
 
-    let public_token = UntrustedToken::<V2>::try_from(
+    let public_token = UntrustedToken::<Public, V2>::try_from(
         &version2::PublicToken::sign(&sk, &pk, message.as_bytes(), None).unwrap(),
     )
     .unwrap();
@@ -52,13 +52,13 @@ fn fuzztest_v2(data: &[u8], csprng: &mut ChaCha20Rng) {
     };
 
     // Local
-    if let Ok(untrusted) = UntrustedToken::<V2>::try_from(&message) {
+    if let Ok(untrusted) = UntrustedToken::<Local, V2>::try_from(&message) {
         if version2::LocalToken::decrypt(&sk_local, &untrusted, None).is_ok() {
             panic!("Invalid token was verified with version 2");
         }
     }
 
-    let local_token = UntrustedToken::<V2>::try_from(
+    let local_token = UntrustedToken::<Local, V2>::try_from(
         &version2::LocalToken::encrypt(&sk_local, message.as_bytes(), None).unwrap(),
     )
     .unwrap();
@@ -81,13 +81,13 @@ fn fuzztest_v3(data: &[u8]) {
     }
 
     // Public
-    if let Ok(untrusted) = UntrustedToken::<V3>::try_from(&message) {
+    if let Ok(untrusted) = UntrustedToken::<Public, V3>::try_from(&message) {
         if version3::PublicToken::verify(&kp.public, &untrusted, None, None).is_ok() {
             panic!("Invalid token was verified with version 3");
         }
     }
 
-    let public_token = UntrustedToken::<V3>::try_from(
+    let public_token = UntrustedToken::<Public, V3>::try_from(
         &version3::PublicToken::sign(&kp.secret, &kp.public, message.as_bytes(), None, None)
             .unwrap(),
     )
@@ -118,13 +118,13 @@ fn fuzztest_v4(data: &[u8], csprng: &mut ChaCha20Rng) {
     }
 
     // Public
-    if let Ok(untrusted) = UntrustedToken::<V4>::try_from(&message) {
+    if let Ok(untrusted) = UntrustedToken::<Public, V4>::try_from(&message) {
         if version4::PublicToken::verify(&pk, &untrusted, None, None).is_ok() {
             panic!("Invalid token was verified with version 4");
         }
     }
 
-    let public_token = UntrustedToken::<V4>::try_from(
+    let public_token = UntrustedToken::<Public, V4>::try_from(
         &version4::PublicToken::sign(&sk, &pk, message.as_bytes(), None, None).unwrap(),
     )
     .unwrap();
@@ -137,13 +137,13 @@ fn fuzztest_v4(data: &[u8], csprng: &mut ChaCha20Rng) {
         Err(_) => panic!("Valid token was NOT verified with version 4"),
     };
     // Local
-    if let Ok(untrusted) = UntrustedToken::<V4>::try_from(&message) {
+    if let Ok(untrusted) = UntrustedToken::<Local, V4>::try_from(&message) {
         if version4::LocalToken::decrypt(&sk_local, &untrusted, None, None).is_ok() {
             panic!("Invalid token was verified with version 4");
         }
     }
 
-    let local_token = UntrustedToken::<V4>::try_from(
+    let local_token = UntrustedToken::<Local, V4>::try_from(
         &version4::LocalToken::encrypt(&sk_local, message.as_bytes(), None, None).unwrap(),
     )
     .unwrap();
@@ -177,7 +177,7 @@ fn fuzz_highlevel(data: &[u8], csprng: &mut ChaCha20Rng) {
     claims.subject("test").unwrap();
     let validation_rules = ClaimsValidationRules::new();
 
-    let public_token = UntrustedToken::<V4>::try_from(
+    let public_token = UntrustedToken::<Public, V4>::try_from(
         &pasetors::public::sign(&sk, &pk, &claims, None, None).unwrap(),
     )
     .unwrap();
@@ -189,7 +189,7 @@ fn fuzz_highlevel(data: &[u8], csprng: &mut ChaCha20Rng) {
         panic!("(high-level API): Valid token was NOT verified with version 4");
     }
 
-    let local_token = UntrustedToken::<V4>::try_from(
+    let local_token = UntrustedToken::<Local, V4>::try_from(
         &pasetors::local::encrypt(&sk_local, &claims, None, None).unwrap(),
     )
     .unwrap();

--- a/fuzz/fuzz_targets/fuzz_pasetors.rs
+++ b/fuzz/fuzz_targets/fuzz_pasetors.rs
@@ -6,10 +6,13 @@ extern crate rand_core;
 
 use libfuzzer_sys::fuzz_target;
 
+use core::convert::TryFrom;
 use ed25519_compact::{KeyPair, Seed};
 use pasetors::claims::*;
 use pasetors::keys::*;
+use pasetors::token::UntrustedToken;
 use pasetors::{version2, version3, version4};
+use pasetors::{V2, V3, V4};
 use rand_chacha::ChaCha20Rng;
 use rand_core::{RngCore, SeedableRng};
 
@@ -29,22 +32,44 @@ fn fuzztest_v2(data: &[u8], csprng: &mut ChaCha20Rng) {
     }
 
     // Public
-    if version2::PublicToken::verify(&pk, &message, None).is_ok() {
-        panic!("Invalid token was verified with version 2");
-    }
-    let public_token = version2::PublicToken::sign(&sk, &pk, message.as_bytes(), None).unwrap();
-    if version2::PublicToken::verify(&pk, &public_token, None).is_err() {
-        panic!("Valid token was NOT verified with version 2");
-    }
-    // Local
-    if version2::LocalToken::decrypt(&sk_local, &message, None).is_ok() {
-        panic!("Invalid token was verified with version 2");
+    if let Ok(untrusted) = UntrustedToken::<V2>::try_from(&message) {
+        if version2::PublicToken::verify(&pk, &untrusted, None).is_ok() {
+            panic!("Invalid token was verified with version 2");
+        }
     }
 
-    let local_token = version2::LocalToken::encrypt(&sk_local, message.as_bytes(), None).unwrap();
-    if version2::LocalToken::decrypt(&sk_local, &local_token, None).is_err() {
-        panic!("Valid token was NOT verified with version 2");
+    let public_token = UntrustedToken::<V2>::try_from(
+        &version2::PublicToken::sign(&sk, &pk, message.as_bytes(), None).unwrap(),
+    )
+    .unwrap();
+    match version2::PublicToken::verify(&pk, &public_token, None) {
+        Ok(trusted) => {
+            assert_eq!(trusted.payload(), message);
+            assert!(trusted.footer().is_empty());
+            assert!(trusted.implicit_assert().is_empty());
+        }
+        Err(_) => panic!("Valid token was NOT verified with version 2"),
+    };
+
+    // Local
+    if let Ok(untrusted) = UntrustedToken::<V2>::try_from(&message) {
+        if version2::LocalToken::decrypt(&sk_local, &untrusted, None).is_ok() {
+            panic!("Invalid token was verified with version 2");
+        }
     }
+
+    let local_token = UntrustedToken::<V2>::try_from(
+        &version2::LocalToken::encrypt(&sk_local, message.as_bytes(), None).unwrap(),
+    )
+    .unwrap();
+    match version2::LocalToken::decrypt(&sk_local, &local_token, None) {
+        Ok(trusted) => {
+            assert_eq!(trusted.payload(), message);
+            assert!(trusted.footer().is_empty());
+            assert!(trusted.implicit_assert().is_empty());
+        }
+        Err(_) => panic!("Valid token was NOT verified with version 2"),
+    };
 }
 
 fn fuzztest_v3(data: &[u8]) {
@@ -56,15 +81,25 @@ fn fuzztest_v3(data: &[u8]) {
     }
 
     // Public
-    if version3::PublicToken::verify(&kp.public, &message, None, None).is_ok() {
-        panic!("Invalid token was verified with version 3");
+    if let Ok(untrusted) = UntrustedToken::<V3>::try_from(&message) {
+        if version3::PublicToken::verify(&kp.public, &untrusted, None, None).is_ok() {
+            panic!("Invalid token was verified with version 3");
+        }
     }
-    let public_token =
-        version3::PublicToken::sign(&kp.secret, &kp.public, message.as_bytes(), None, None)
-            .unwrap();
-    if version3::PublicToken::verify(&kp.public, &public_token, None, None).is_err() {
-        panic!("Valid token was NOT verified with version 3");
-    }
+
+    let public_token = UntrustedToken::<V3>::try_from(
+        &version3::PublicToken::sign(&kp.secret, &kp.public, message.as_bytes(), None, None)
+            .unwrap(),
+    )
+    .unwrap();
+    match version3::PublicToken::verify(&kp.public, &public_token, None, None) {
+        Ok(trusted) => {
+            assert_eq!(trusted.payload(), message);
+            assert!(trusted.footer().is_empty());
+            assert!(trusted.implicit_assert().is_empty());
+        }
+        Err(_) => panic!("Valid token was NOT verified with version 3"),
+    };
 }
 
 fn fuzztest_v4(data: &[u8], csprng: &mut ChaCha20Rng) {
@@ -83,24 +118,43 @@ fn fuzztest_v4(data: &[u8], csprng: &mut ChaCha20Rng) {
     }
 
     // Public
-    if version4::PublicToken::verify(&pk, &message, None, None).is_ok() {
-        panic!("Invalid token was verified with version 4");
-    }
-    let public_token =
-        version4::PublicToken::sign(&sk, &pk, message.as_bytes(), None, None).unwrap();
-    if version4::PublicToken::verify(&pk, &public_token, None, None).is_err() {
-        panic!("Valid token was NOT verified with version 4");
-    }
-    // Local
-    if version4::LocalToken::decrypt(&sk_local, &message, None, None).is_ok() {
-        panic!("Invalid token was verified with version 4");
+    if let Ok(untrusted) = UntrustedToken::<V4>::try_from(&message) {
+        if version4::PublicToken::verify(&pk, &untrusted, None, None).is_ok() {
+            panic!("Invalid token was verified with version 4");
+        }
     }
 
-    let local_token =
-        version4::LocalToken::encrypt(&sk_local, message.as_bytes(), None, None).unwrap();
-    if version4::LocalToken::decrypt(&sk_local, &local_token, None, None).is_err() {
-        panic!("Valid token was NOT verified with version 4");
+    let public_token = UntrustedToken::<V4>::try_from(
+        &version4::PublicToken::sign(&sk, &pk, message.as_bytes(), None, None).unwrap(),
+    )
+    .unwrap();
+    match version4::PublicToken::verify(&pk, &public_token, None, None) {
+        Ok(trusted) => {
+            assert_eq!(trusted.payload(), message);
+            assert!(trusted.footer().is_empty());
+            assert!(trusted.implicit_assert().is_empty());
+        }
+        Err(_) => panic!("Valid token was NOT verified with version 4"),
+    };
+    // Local
+    if let Ok(untrusted) = UntrustedToken::<V4>::try_from(&message) {
+        if version4::LocalToken::decrypt(&sk_local, &untrusted, None, None).is_ok() {
+            panic!("Invalid token was verified with version 4");
+        }
     }
+
+    let local_token = UntrustedToken::<V4>::try_from(
+        &version4::LocalToken::encrypt(&sk_local, message.as_bytes(), None, None).unwrap(),
+    )
+    .unwrap();
+    match version4::LocalToken::decrypt(&sk_local, &local_token, None, None) {
+        Ok(trusted) => {
+            assert_eq!(trusted.payload(), message);
+            assert!(trusted.footer().is_empty());
+            assert!(trusted.implicit_assert().is_empty());
+        }
+        Err(_) => panic!("Valid token was NOT verified with version 4"),
+    };
 }
 
 fn fuzz_highlevel(data: &[u8], csprng: &mut ChaCha20Rng) {
@@ -123,80 +177,28 @@ fn fuzz_highlevel(data: &[u8], csprng: &mut ChaCha20Rng) {
     claims.subject("test").unwrap();
     let validation_rules = ClaimsValidationRules::new();
 
-    let public_token = pasetors::public::sign(&sk, &pk, &claims, None, None).unwrap();
-    if let Ok(claims_from) =
+    let public_token = UntrustedToken::<V4>::try_from(
+        &pasetors::public::sign(&sk, &pk, &claims, None, None).unwrap(),
+    )
+    .unwrap();
+    if let Ok(trusted_token) =
         pasetors::public::verify(&pk, &public_token, &validation_rules, None, None)
     {
-        assert_eq!(claims, claims_from);
+        assert_eq!(&claims, trusted_token.payload_claims().unwrap());
     } else {
         panic!("(high-level API): Valid token was NOT verified with version 4");
     }
 
-    let local_token = pasetors::local::encrypt(&sk_local, &claims, None, None).unwrap();
-    if let Ok(claims_from) =
+    let local_token = UntrustedToken::<V4>::try_from(
+        &pasetors::local::encrypt(&sk_local, &claims, None, None).unwrap(),
+    )
+    .unwrap();
+    if let Ok(trusted_token) =
         pasetors::local::decrypt(&sk_local, &local_token, &validation_rules, None, None)
     {
-        assert_eq!(claims, claims_from);
+        assert_eq!(&claims, trusted_token.payload_claims().unwrap());
     } else {
         panic!("(high-level API): Valid token was NOT verified with version 4");
-    }
-}
-
-fn fuzz_paserk(data: &[u8]) {
-    use core::convert::TryFrom;
-    use pasetors::paserk::{FormatAsPaserk, Id};
-
-    let data: String = String::from_utf8_lossy(data).into();
-
-    if let Ok(valid_paserk) = AsymmetricKeyPair::<V2>::try_from(data.clone()) {
-        let mut buf = String::new();
-        valid_paserk.fmt(&mut buf).unwrap();
-        assert_eq!(&data, &buf);
-        let _ = Id::from(&valid_paserk);
-    }
-    if let Ok(valid_paserk) = AsymmetricSecretKey::<V3>::try_from(data.clone()) {
-        let mut buf = String::new();
-        valid_paserk.fmt(&mut buf).unwrap();
-        assert_eq!(&data, &buf);
-        let _ = Id::from(&valid_paserk);
-    }
-    if let Ok(valid_paserk) = AsymmetricKeyPair::<V4>::try_from(data.clone()) {
-        let mut buf = String::new();
-        valid_paserk.fmt(&mut buf).unwrap();
-        assert_eq!(&data, &buf);
-        let _ = Id::from(&valid_paserk);
-    }
-
-    if let Ok(valid_paserk) = AsymmetricPublicKey::<V2>::try_from(data.clone()) {
-        let mut buf = String::new();
-        valid_paserk.fmt(&mut buf).unwrap();
-        assert_eq!(&data, &buf);
-        let _ = Id::from(&valid_paserk);
-    }
-    if let Ok(valid_paserk) = AsymmetricPublicKey::<V3>::try_from(data.clone()) {
-        let mut buf = String::new();
-        valid_paserk.fmt(&mut buf).unwrap();
-        assert_eq!(&data, &buf);
-        let _ = Id::from(&valid_paserk);
-    }
-    if let Ok(valid_paserk) = AsymmetricPublicKey::<V4>::try_from(data.clone()) {
-        let mut buf = String::new();
-        valid_paserk.fmt(&mut buf).unwrap();
-        assert_eq!(&data, &buf);
-        let _ = Id::from(&valid_paserk);
-    }
-
-    if let Ok(valid_paserk) = SymmetricKey::<V2>::try_from(data.clone()) {
-        let mut buf = String::new();
-        valid_paserk.fmt(&mut buf).unwrap();
-        assert_eq!(&data, &buf);
-        let _ = Id::from(&valid_paserk);
-    }
-    if let Ok(valid_paserk) = SymmetricKey::<V4>::try_from(data.clone()) {
-        let mut buf = String::new();
-        valid_paserk.fmt(&mut buf).unwrap();
-        assert_eq!(&data, &buf);
-        let _ = Id::from(&valid_paserk);
     }
 }
 
@@ -207,9 +209,4 @@ fuzz_target!(|data: &[u8]| {
     fuzztest_v3(data);
     fuzztest_v4(data, &mut csprng);
     fuzz_highlevel(data, &mut csprng);
-    fuzz_paserk(data);
-
-    if let Ok(parsed_claims) = Claims::from_bytes(data) {
-        assert!(parsed_claims.to_string().is_ok());
-    }
 });

--- a/fuzz/fuzz_targets/fuzz_point_comp.rs
+++ b/fuzz/fuzz_targets/fuzz_point_comp.rs
@@ -8,6 +8,7 @@ use libfuzzer_sys::fuzz_target;
 use core::convert::TryFrom;
 use pasetors::keys::*;
 use pasetors::version3::UncompressedPublicKey;
+use pasetors::V3;
 use ring::signature::{
     EcdsaKeyPair, KeyPair, UnparsedPublicKey, ECDSA_P384_SHA384_FIXED,
     ECDSA_P384_SHA384_FIXED_SIGNING,

--- a/fuzz/fuzz_targets/fuzz_types.rs
+++ b/fuzz/fuzz_targets/fuzz_types.rs
@@ -1,0 +1,32 @@
+#![no_main]
+extern crate pasetors;
+
+use core::convert::TryFrom;
+use libfuzzer_sys::fuzz_target;
+use pasetors::claims::*;
+use pasetors::token::UntrustedToken;
+use pasetors::{V2, V3, V4};
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(parsed_claims) = Claims::from_bytes(data) {
+        assert!(parsed_claims.to_string().is_ok());
+    }
+
+    let message: String = String::from_utf8_lossy(data).into();
+
+    if let Ok(untrusted_v2) = UntrustedToken::<V2>::try_from(message.as_str()) {
+        assert!(!untrusted_v2.untrusted_header().is_empty());
+        assert!(!untrusted_v2.untrusted_message().is_empty());
+        assert!(!untrusted_v2.untrusted_payload().is_empty());
+    }
+    if let Ok(untrusted_v3) = UntrustedToken::<V3>::try_from(message.as_str()) {
+        assert!(!untrusted_v3.untrusted_header().is_empty());
+        assert!(!untrusted_v3.untrusted_message().is_empty());
+        assert!(!untrusted_v3.untrusted_payload().is_empty());
+    }
+    if let Ok(untrusted_v4) = UntrustedToken::<V4>::try_from(message.as_str()) {
+        assert!(!untrusted_v4.untrusted_header().is_empty());
+        assert!(!untrusted_v4.untrusted_message().is_empty());
+        assert!(!untrusted_v4.untrusted_payload().is_empty());
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_types.rs
+++ b/fuzz/fuzz_targets/fuzz_types.rs
@@ -5,7 +5,7 @@ use core::convert::TryFrom;
 use libfuzzer_sys::fuzz_target;
 use pasetors::claims::*;
 use pasetors::token::UntrustedToken;
-use pasetors::{V2, V3, V4};
+use pasetors::{Local, Public, V2, V3, V4};
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(parsed_claims) = Claims::from_bytes(data) {
@@ -14,19 +14,28 @@ fuzz_target!(|data: &[u8]| {
 
     let message: String = String::from_utf8_lossy(data).into();
 
-    if let Ok(untrusted_v2) = UntrustedToken::<V2>::try_from(message.as_str()) {
-        assert!(!untrusted_v2.untrusted_header().is_empty());
-        assert!(!untrusted_v2.untrusted_message().is_empty());
-        assert!(!untrusted_v2.untrusted_payload().is_empty());
+    if let Ok(untrusted_v2_public) = UntrustedToken::<Public, V2>::try_from(message.as_str()) {
+        assert!(!untrusted_v2_public.untrusted_message().is_empty());
+        assert!(!untrusted_v2_public.untrusted_payload().is_empty());
     }
-    if let Ok(untrusted_v3) = UntrustedToken::<V3>::try_from(message.as_str()) {
-        assert!(!untrusted_v3.untrusted_header().is_empty());
-        assert!(!untrusted_v3.untrusted_message().is_empty());
-        assert!(!untrusted_v3.untrusted_payload().is_empty());
+    if let Ok(untrusted_v2_local) = UntrustedToken::<Local, V2>::try_from(message.as_str()) {
+        assert!(!untrusted_v2_local.untrusted_message().is_empty());
+        assert!(!untrusted_v2_local.untrusted_payload().is_empty());
     }
-    if let Ok(untrusted_v4) = UntrustedToken::<V4>::try_from(message.as_str()) {
-        assert!(!untrusted_v4.untrusted_header().is_empty());
-        assert!(!untrusted_v4.untrusted_message().is_empty());
-        assert!(!untrusted_v4.untrusted_payload().is_empty());
+    if let Ok(untrusted_v3_public) = UntrustedToken::<Public, V3>::try_from(message.as_str()) {
+        assert!(!untrusted_v3_public.untrusted_message().is_empty());
+        assert!(!untrusted_v3_public.untrusted_payload().is_empty());
+    }
+    if let Ok(untrusted_v3_local) = UntrustedToken::<Local, V3>::try_from(message.as_str()) {
+        assert!(!untrusted_v3_local.untrusted_message().is_empty());
+        assert!(!untrusted_v3_local.untrusted_payload().is_empty());
+    }
+    if let Ok(untrusted_v4_public) = UntrustedToken::<Public, V4>::try_from(message.as_str()) {
+        assert!(!untrusted_v4_public.untrusted_message().is_empty());
+        assert!(!untrusted_v4_public.untrusted_payload().is_empty());
+    }
+    if let Ok(untrusted_v4_local) = UntrustedToken::<Local, V4>::try_from(message.as_str()) {
+        assert!(!untrusted_v4_local.untrusted_message().is_empty());
+        assert!(!untrusted_v4_local.untrusted_payload().is_empty());
     }
 });

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,4 +1,5 @@
 use crate::errors::Error;
+use crate::token::private::Purpose;
 use crate::token::UntrustedToken;
 use crate::version::private::Version;
 use alloc::string::String;
@@ -31,9 +32,9 @@ pub(crate) fn decode_b64<T: AsRef<[u8]>>(encoded: T) -> Result<Vec<u8>, Error> {
 /// Validate that a token begins with a given header.purpose and does not contain more than:
 /// header.purpose.payload.footer
 /// If a footer is present, this is validated against the supplied.
-pub(crate) fn validate_format_untrusted_token<'a, V: Version>(
+pub(crate) fn validate_format_untrusted_token<'a, T: Purpose<V>, V: Version>(
     header: &'a str,
-    token: &UntrustedToken<V>,
+    token: &UntrustedToken<T, V>,
     footer: Option<&[u8]>,
 ) -> Result<(), Error> {
     if token.untrusted_header() != header {

--- a/src/common.rs
+++ b/src/common.rs
@@ -29,18 +29,11 @@ pub(crate) fn decode_b64<T: AsRef<[u8]>>(encoded: T) -> Result<Vec<u8>, Error> {
     Ok(ret)
 }
 
-/// Validate that a token begins with a given header.purpose and does not contain more than:
-/// header.purpose.payload.footer
 /// If a footer is present, this is validated against the supplied.
-pub(crate) fn validate_format_untrusted_token<'a, T: Purpose<V>, V: Version>(
-    header: &'a str,
+pub(crate) fn validate_footer_untrusted_token<T: Purpose<V>, V: Version>(
     token: &UntrustedToken<T, V>,
     footer: Option<&[u8]>,
 ) -> Result<(), Error> {
-    if token.untrusted_header() != header {
-        return Err(Error::TokenFormat);
-    }
-
     // A known footer was supplied for comparison.
     if let Some(known_footer) = footer {
         if token.untrusted_footer().is_empty() {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -33,6 +33,8 @@ pub enum Error {
     PublicKeyConversion,
     /// Error during key generation.
     KeyGeneration,
+    /// The payload was not valid UTF-8.
+    PayloadInvalidUtf8,
 }
 
 #[cfg(feature = "std")]

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,9 +1,15 @@
 use crate::errors::Error;
 use crate::version::private::Version;
-use crate::{V2, V3, V4};
+use crate::V4;
 use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::marker::PhantomData;
+
+#[cfg(feature = "v2")]
+use crate::V2;
+
+#[cfg(feature = "v3")]
+use crate::V3;
 
 /// A type `T` that can be generated for a given version `V`.
 pub trait Generate<T, V: Version> {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,114 +1,14 @@
 use crate::errors::Error;
+use crate::version::private::Version;
+use crate::{V2, V3, V4};
 use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::marker::PhantomData;
-use private::Version;
-
-pub(crate) mod private {
-    use super::Error;
-
-    // Inside private module to prevent users from implementing this themself.
-
-    /// A given version must implement validation logic in terms of both itself and the kind of key.
-    pub trait Version {
-        /// Size for a `local` key.
-        const LOCAL: usize;
-        /// Size for a secret `public` key.
-        const SECRET: usize;
-        /// Size for a public `public` key.
-        const PUBLIC: usize;
-
-        /// Validate bytes for a `local` key of a given version.
-        fn validate_local(key_bytes: &[u8]) -> Result<(), Error>;
-        /// Validate bytes for a secret `public` key of a given version.
-        fn validate_secret(key_bytes: &[u8]) -> Result<(), Error>;
-        /// Validate bytes for a public `local` key of a given version.
-        fn validate_public(key_bytes: &[u8]) -> Result<(), Error>;
-    }
-}
 
 /// A type `T` that can be generated for a given version `V`.
 pub trait Generate<T, V: Version> {
     /// Generate `T`.
     fn generate() -> Result<T, Error>;
-}
-
-/// Version 2 of the PASETO spec.
-pub struct V2;
-
-/// Version 3 of the PASETO spec.
-pub struct V3;
-
-/// Version 4 of the PASETO spec.
-pub struct V4;
-
-impl Version for V2 {
-    const LOCAL: usize = 32;
-    const SECRET: usize = 32;
-    const PUBLIC: usize = 32;
-
-    fn validate_local(key_bytes: &[u8]) -> Result<(), Error> {
-        if key_bytes.len() != Self::LOCAL {
-            return Err(Error::Key);
-        }
-
-        Ok(())
-    }
-
-    fn validate_secret(key_bytes: &[u8]) -> Result<(), Error> {
-        Self::validate_local(key_bytes)
-    }
-
-    fn validate_public(key_bytes: &[u8]) -> Result<(), Error> {
-        Self::validate_secret(key_bytes)
-    }
-}
-
-impl Version for V3 {
-    const LOCAL: usize = 32;
-    const SECRET: usize = 48;
-    const PUBLIC: usize = 49;
-
-    fn validate_local(_key_bytes: &[u8]) -> Result<(), Error> {
-        unimplemented!();
-    }
-
-    fn validate_secret(key_bytes: &[u8]) -> Result<(), Error> {
-        if key_bytes.len() != Self::SECRET {
-            return Err(Error::Key);
-        }
-
-        Ok(())
-    }
-
-    fn validate_public(key_bytes: &[u8]) -> Result<(), Error> {
-        if key_bytes.len() != Self::PUBLIC {
-            return Err(Error::Key);
-        }
-        if key_bytes[0] != 0x02 && key_bytes[0] != 0x03 {
-            return Err(Error::Key);
-        }
-
-        Ok(())
-    }
-}
-
-impl Version for V4 {
-    const LOCAL: usize = V2::LOCAL;
-    const SECRET: usize = V2::SECRET;
-    const PUBLIC: usize = V2::PUBLIC;
-
-    fn validate_local(key_bytes: &[u8]) -> Result<(), Error> {
-        V2::validate_local(key_bytes)
-    }
-
-    fn validate_secret(key_bytes: &[u8]) -> Result<(), Error> {
-        V2::validate_secret(key_bytes)
-    }
-
-    fn validate_public(key_bytes: &[u8]) -> Result<(), Error> {
-        V2::validate_public(key_bytes)
-    }
 }
 
 /// A symmetric key used for `.local` tokens, given a version `V`.
@@ -120,7 +20,7 @@ pub struct SymmetricKey<V> {
 impl<V: Version> SymmetricKey<V> {
     /// Create a `SymmetricKey` from `bytes`.
     pub fn from(bytes: &[u8]) -> Result<Self, Error> {
-        V::validate_local(bytes)?;
+        V::validate_local_key(bytes)?;
 
         Ok(Self {
             bytes: bytes.to_vec(),
@@ -156,7 +56,7 @@ pub struct AsymmetricSecretKey<V> {
 impl<V: Version> AsymmetricSecretKey<V> {
     /// Create a `AsymmetricSecretKey` from `bytes`.
     pub fn from(bytes: &[u8]) -> Result<Self, Error> {
-        V::validate_secret(bytes)?;
+        V::validate_secret_key(bytes)?;
 
         Ok(Self {
             bytes: bytes.to_vec(),
@@ -193,7 +93,7 @@ pub struct AsymmetricPublicKey<V> {
 impl<V: Version> AsymmetricPublicKey<V> {
     /// Create a `AsymmetricPublicKey` from `bytes`.
     pub fn from(bytes: &[u8]) -> Result<Self, Error> {
-        V::validate_public(bytes)?;
+        V::validate_public_key(bytes)?;
 
         Ok(Self {
             bytes: bytes.to_vec(),
@@ -237,8 +137,8 @@ impl Generate<AsymmetricKeyPair<V2>, V2> for AsymmetricKeyPair<V2> {
 #[cfg(feature = "v2")]
 impl Generate<SymmetricKey<V2>, V2> for SymmetricKey<V2> {
     fn generate() -> Result<SymmetricKey<V2>, Error> {
-        let mut rng_bytes = vec![0u8; V2::LOCAL];
-        V2::validate_local(&rng_bytes)?;
+        let mut rng_bytes = vec![0u8; V2::LOCAL_KEY];
+        V2::validate_local_key(&rng_bytes)?;
         getrandom::getrandom(&mut rng_bytes)?;
 
         Ok(Self {
@@ -272,7 +172,7 @@ impl Generate<AsymmetricKeyPair<V3>, V3> for AsymmetricKeyPair<V3> {
 
         // *ring* includes the public key in the PKCS8 doc, so we error if it for some reason isn't available.
         // src: https://briansmith.org/rustdoc/ring/signature/struct.EcdsaKeyPair.html#method.generate_pkcs8
-        let parsed_ec_private_key = sec1::EcPrivateKey::from_der(&private_key_info.private_key)
+        let parsed_ec_private_key = sec1::EcPrivateKey::from_der(private_key_info.private_key)
             .map_err(|_| Error::KeyGeneration)?;
 
         let public_uc = match parsed_ec_private_key.public_key {
@@ -291,8 +191,8 @@ impl Generate<AsymmetricKeyPair<V3>, V3> for AsymmetricKeyPair<V3> {
 #[cfg(feature = "v4")]
 impl Generate<SymmetricKey<V4>, V4> for SymmetricKey<V4> {
     fn generate() -> Result<SymmetricKey<V4>, Error> {
-        let mut rng_bytes = vec![0u8; V4::LOCAL];
-        V4::validate_local(&rng_bytes)?;
+        let mut rng_bytes = vec![0u8; V4::LOCAL_KEY];
+        V4::validate_local_key(&rng_bytes)?;
         getrandom::getrandom(&mut rng_bytes)?;
 
         Ok(Self {
@@ -324,20 +224,20 @@ impl Generate<AsymmetricKeyPair<V4>, V4> for AsymmetricKeyPair<V4> {
 // NOTE: Only intended for V2/V4 testing purposes.
 impl<V: Version> AsymmetricKeyPair<V> {
     pub(crate) fn from(bytes: &[u8]) -> Result<Self, Error> {
-        if bytes.len() != V2::SECRET + V2::PUBLIC {
+        if bytes.len() != V2::SECRET_KEY + V2::PUBLIC_KEY {
             return Err(Error::PaserkParsing);
         }
 
         Ok(Self {
-            secret: AsymmetricSecretKey::from(&bytes[..V2::SECRET])?,
-            public: AsymmetricPublicKey::from(&bytes[V2::SECRET..])?,
+            secret: AsymmetricSecretKey::from(&bytes[..V2::SECRET_KEY])?,
+            public: AsymmetricPublicKey::from(&bytes[V2::SECRET_KEY..])?,
         })
     }
 
     pub(crate) fn as_bytes<'a>(&self) -> [u8; 64] {
-        let mut buf = [0u8; V2::SECRET + V2::PUBLIC];
-        buf[..V2::SECRET].copy_from_slice(self.secret.as_bytes());
-        buf[V2::SECRET..].copy_from_slice(self.public.as_bytes());
+        let mut buf = [0u8; V2::SECRET_KEY + V2::PUBLIC_KEY];
+        buf[..V2::SECRET_KEY].copy_from_slice(self.secret.as_bytes());
+        buf[V2::SECRET_KEY..].copy_from_slice(self.public.as_bytes());
 
         buf
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,9 @@ pub mod version3;
 /// PASETO version 4 tokens.
 pub mod version4;
 
+/// Types for handling tokens.
+pub mod token;
+
 #[cfg_attr(docsrs, doc(cfg(all(feature = "std", feature = "v4"))))]
 #[cfg(all(feature = "std", feature = "v4"))]
 /// PASETO public tokens with [`version4`], using [`claims::Claims`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! ```rust
 //! use pasetors::claims::{Claims, ClaimsValidationRules};
 //! use pasetors::keys::{Generate, AsymmetricKeyPair, AsymmetricSecretKey, AsymmetricPublicKey};
-//! use pasetors::{public, V4};
+//! use pasetors::{public, Public, V4};
 //! use pasetors::token::{UntrustedToken, TrustedToken};
 //! use core::convert::TryFrom;
 //!
@@ -33,7 +33,7 @@
 //! // NOTE: Custom claims, defined through `add_additional()`, are not validated. This must be done
 //! // manually.
 //! let validation_rules = ClaimsValidationRules::new();
-//! let untrusted_token = UntrustedToken::try_from(&pub_token)?;
+//! let untrusted_token = UntrustedToken::<Public, V4>::try_from(&pub_token)?;
 //! let trusted_token = public::verify(&kp.public, &untrusted_token, &validation_rules, Some(b"footer"), Some(b"implicit assertion"))?;
 //! assert_eq!(&claims, trusted_token.payload_claims().unwrap());
 //!
@@ -49,7 +49,7 @@
 //! ```rust
 //! use pasetors::claims::{Claims, ClaimsValidationRules};
 //! use pasetors::keys::{Generate, SymmetricKey};
-//! use pasetors::{local, V4};
+//! use pasetors::{local, Local, V4};
 //! use pasetors::token::UntrustedToken;
 //! use core::convert::TryFrom;
 //!
@@ -68,7 +68,7 @@
 //! // NOTE: Custom claims, defined through `add_additional()`, are not validated. This must be done
 //! // manually.
 //! let validation_rules = ClaimsValidationRules::new();
-//! let untrusted_token = UntrustedToken::try_from(&token)?;
+//! let untrusted_token = UntrustedToken::<Local, V4>::try_from(&token)?;
 //! let trusted_token = local::decrypt(&sk, &untrusted_token, &validation_rules, Some(b"footer"), Some(b"implicit assertion"))?;
 //! assert_eq!(&claims, trusted_token.payload_claims().unwrap());
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,6 +191,9 @@ mod version;
 /// Versions of the PASETO spec implemented.
 pub use version::{V2, V3, V4};
 
+/// Public and local tokens.
+pub use token::{Local, Public};
+
 #[cfg_attr(docsrs, doc(cfg(all(feature = "std", feature = "v4"))))]
 #[cfg(all(feature = "std", feature = "v4"))]
 /// PASETO public tokens with [`version4`], using [`claims::Claims`].
@@ -222,7 +225,7 @@ pub mod public {
     /// validate the claims according to the `validation_rules`.
     pub fn verify(
         public_key: &AsymmetricPublicKey<V4>,
-        token: &UntrustedToken<V4>,
+        token: &UntrustedToken<Public, V4>,
         validation_rules: &ClaimsValidationRules,
         footer: Option<&[u8]>,
         implicit_assert: Option<&[u8]>,
@@ -267,7 +270,7 @@ pub mod local {
     /// validate the claims according to the `validation_rules`.
     pub fn decrypt(
         secret_key: &SymmetricKey<V4>,
-        token: &UntrustedToken<V4>,
+        token: &UntrustedToken<Local, V4>,
         validation_rules: &ClaimsValidationRules,
         footer: Option<&[u8]>,
         implicit_assert: Option<&[u8]>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,10 @@
 //! ## Creating and verifying public tokens
 //! ```rust
 //! use pasetors::claims::{Claims, ClaimsValidationRules};
-//! use pasetors::keys::{Generate, AsymmetricKeyPair, AsymmetricSecretKey, AsymmetricPublicKey, V4};
-//! use pasetors::public;
+//! use pasetors::keys::{Generate, AsymmetricKeyPair, AsymmetricSecretKey, AsymmetricPublicKey};
+//! use pasetors::{public, V4};
+//! use pasetors::token::{UntrustedToken, TrustedToken};
+//! use core::convert::TryFrom;
 //!
 //! // Setup the default claims, which include `iat` and `nbf` as the current time and `exp` of one hour.
 //! // Add a custom `data` claim as well.
@@ -31,8 +33,11 @@
 //! // NOTE: Custom claims, defined through `add_additional()`, are not validated. This must be done
 //! // manually.
 //! let validation_rules = ClaimsValidationRules::new();
-//! let claims_from = public::verify(&kp.public, &pub_token, &validation_rules, Some(b"footer"), Some(b"implicit assertion"))?;
-//! assert_eq!(claims, claims_from);
+//! let untrusted_token = UntrustedToken::try_from(&pub_token)?;
+//! let trusted_token = public::verify(&kp.public, &untrusted_token, &validation_rules, Some(b"footer"), Some(b"implicit assertion"))?;
+//! assert_eq!(&claims, trusted_token.payload_claims().unwrap());
+//!
+//! let claims = trusted_token.payload_claims().unwrap();
 //!
 //! println!("{:?}", claims.get_claim("data"));
 //! println!("{:?}", claims.get_claim("iat"));
@@ -43,8 +48,10 @@
 //! ## Creating and verifying local tokens
 //! ```rust
 //! use pasetors::claims::{Claims, ClaimsValidationRules};
-//! use pasetors::keys::{Generate, SymmetricKey, V4};
-//! use pasetors::local;
+//! use pasetors::keys::{Generate, SymmetricKey};
+//! use pasetors::{local, V4};
+//! use pasetors::token::UntrustedToken;
+//! use core::convert::TryFrom;
 //!
 //! // Setup the default claims, which include `iat` and `nbf` as the current time and `exp` of one hour.
 //! // Add a custom `data` claim as well.
@@ -61,8 +68,11 @@
 //! // NOTE: Custom claims, defined through `add_additional()`, are not validated. This must be done
 //! // manually.
 //! let validation_rules = ClaimsValidationRules::new();
-//! let claims_from = local::decrypt(&sk, &token, &validation_rules, Some(b"footer"), Some(b"implicit assertion"))?;
-//! assert_eq!(claims, claims_from);
+//! let untrusted_token = UntrustedToken::try_from(&token)?;
+//! let trusted_token = local::decrypt(&sk, &untrusted_token, &validation_rules, Some(b"footer"), Some(b"implicit assertion"))?;
+//! assert_eq!(&claims, trusted_token.payload_claims().unwrap());
+//!
+//! let claims = trusted_token.payload_claims().unwrap();
 //!
 //! println!("{:?}", claims.get_claim("data"));
 //! println!("{:?}", claims.get_claim("iat"));
@@ -114,7 +124,8 @@
 //! ## PASERK serialization
 //! ```rust
 //! use pasetors::paserk::FormatAsPaserk;
-//! use pasetors::keys::{Generate, SymmetricKey, V4};
+//! use pasetors::keys::{Generate, SymmetricKey};
+//! use pasetors::V4;
 //! use core::convert::TryFrom;
 //!
 //! // Generate the key and serialize to and from PASERK.
@@ -175,13 +186,20 @@ pub mod version4;
 /// Types for handling tokens.
 pub mod token;
 
+mod version;
+
+/// Versions of the PASETO spec implemented.
+pub use version::{V2, V3, V4};
+
 #[cfg_attr(docsrs, doc(cfg(all(feature = "std", feature = "v4"))))]
 #[cfg(all(feature = "std", feature = "v4"))]
 /// PASETO public tokens with [`version4`], using [`claims::Claims`].
 pub mod public {
+    use super::*;
     use crate::claims::{Claims, ClaimsValidationRules};
     use crate::errors::Error;
-    use crate::keys::{AsymmetricPublicKey, AsymmetricSecretKey, V4};
+    use crate::keys::{AsymmetricPublicKey, AsymmetricSecretKey};
+    use crate::token::{TrustedToken, UntrustedToken};
 
     /// Create a public token using the latest PASETO version (v4).
     pub fn sign(
@@ -204,22 +222,19 @@ pub mod public {
     /// validate the claims according to the `validation_rules`.
     pub fn verify(
         public_key: &AsymmetricPublicKey<V4>,
-        token: &str,
+        token: &UntrustedToken<V4>,
         validation_rules: &ClaimsValidationRules,
         footer: Option<&[u8]>,
         implicit_assert: Option<&[u8]>,
-    ) -> Result<Claims, Error> {
-        crate::version4::PublicToken::verify(public_key, token, footer, implicit_assert)?;
-        // The token format has been checked during `verify`, where this splitting and indexing
-        // also happens. Therefore, it's assumed safe to do the same here without additional checks.
-        let parts_split = token.split('.').collect::<Vec<&str>>();
-        let token_raw = crate::common::decode_b64(parts_split[2])?;
+    ) -> Result<TrustedToken, Error> {
+        let mut trusted_token =
+            crate::version4::PublicToken::verify(public_key, token, footer, implicit_assert)?;
 
-        let claims =
-            Claims::from_bytes(&token_raw[..token_raw.len() - ed25519_compact::Signature::BYTES])?;
+        let claims = Claims::from_string(trusted_token.payload())?;
         validation_rules.validate_claims(&claims)?;
+        trusted_token.set_payload_claims(claims);
 
-        Ok(claims)
+        Ok(trusted_token)
     }
 }
 
@@ -227,9 +242,11 @@ pub mod public {
 #[cfg(all(feature = "std", feature = "v4"))]
 /// PASETO local tokens with [`version4`], using [`claims::Claims`].
 pub mod local {
+    use super::*;
     use crate::claims::{Claims, ClaimsValidationRules};
     use crate::errors::Error;
-    use crate::keys::{SymmetricKey, V4};
+    use crate::keys::SymmetricKey;
+    use crate::token::{TrustedToken, UntrustedToken};
 
     /// Create a local token using the latest PASETO version (v4).
     pub fn encrypt(
@@ -250,16 +267,18 @@ pub mod local {
     /// validate the claims according to the `validation_rules`.
     pub fn decrypt(
         secret_key: &SymmetricKey<V4>,
-        token: &str,
+        token: &UntrustedToken<V4>,
         validation_rules: &ClaimsValidationRules,
         footer: Option<&[u8]>,
         implicit_assert: Option<&[u8]>,
-    ) -> Result<Claims, Error> {
-        let raw_payload =
+    ) -> Result<TrustedToken, Error> {
+        let mut trusted_token =
             crate::version4::LocalToken::decrypt(secret_key, token, footer, implicit_assert)?;
-        let claims = Claims::from_bytes(&raw_payload)?;
-        validation_rules.validate_claims(&claims)?;
 
-        Ok(claims)
+        let claims = Claims::from_string(trusted_token.payload())?;
+        validation_rules.validate_claims(&claims)?;
+        trusted_token.set_payload_claims(claims);
+
+        Ok(trusted_token)
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -62,12 +62,203 @@ impl UntrustedToken {
     }
 
     /// Return untrusted message of this [`UntrustedToken].
+    /// If it is a local token, this is the encrypted message.
+    /// If it is a public token, the signature is included.
     pub fn get_untrusted_message(&self) -> &[u8] {
         &self.message
     }
 
     /// Return untrusted footer of this [`UntrustedToken].
+    /// Empty if there was no footer in the token.
     pub fn get_untrusted_footer(&self) -> &[u8] {
         &self.footer
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::token::UntrustedToken;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn invalid_tokens() {
+        assert!(UntrustedToken::try_from("v2.public.AAAAA%%%").is_err());
+        assert!(UntrustedToken::try_from("v2.depends.AAAAAAAA").is_err());
+        assert!(UntrustedToken::try_from("v999.public.AAAAA%%%").is_err());
+        assert!(UntrustedToken::try_from("v2.").is_err());
+        assert!(UntrustedToken::try_from("v2.public").is_err());
+    }
+
+    #[cfg(feature = "v2")]
+    #[test]
+    fn valid_v2_local() {
+        // "2-E-1"
+        let valid_no_footer = "v2.local.97TTOvgwIxNGvV80XKiGZg_kD3tsXM_-qB4dZGHOeN1cTkgQ4PnW8888l802W8d9AvEGnoNBY3BnqHORy8a5cC8aKpbA0En8XELw2yDk2f1sVODyfnDbi6rEGMY3pSfCbLWMM2oHJxvlEl2XbQ";
+        // "2-E-5"
+        let valid_with_footer = "v2.local.5K4SCXNhItIhyNuVIZcwrdtaDKiyF81-eWHScuE0idiVqCo72bbjo07W05mqQkhLZdVbxEa5I_u5sgVk1QLkcWEcOSlLHwNpCkvmGGlbCdNExn6Qclw3qTKIIl5-zSLIrxZqOLwcFLYbVK1SrQ.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
+
+        let untrusted_no_footer = UntrustedToken::try_from(valid_no_footer).unwrap();
+        let untrusted_with_footer = UntrustedToken::try_from(valid_with_footer).unwrap();
+
+        // Note: We don't test for untrusted message, since it is encrypted.
+        assert_eq!(
+            untrusted_no_footer.get_untrusted_header(),
+            crate::version2::LocalToken::HEADER
+        );
+        assert_eq!(untrusted_no_footer.get_untrusted_footer(), &[0u8; 0]);
+
+        assert_eq!(
+            untrusted_with_footer.get_untrusted_header(),
+            crate::version2::LocalToken::HEADER
+        );
+        assert_eq!(
+            untrusted_with_footer.get_untrusted_footer(),
+            "{\"kid\":\"zVhMiPBP9fRf2snEcT7gFTioeA9COcNy9DfgL1W60haN\"}".as_bytes()
+        );
+    }
+
+    #[cfg(feature = "v2")]
+    #[test]
+    fn valid_v2_public() {
+        // "2-S-1"
+        let valid_no_footer = "v2.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAxOS0wMS0wMVQwMDowMDowMCswMDowMCJ9HQr8URrGntTu7Dz9J2IF23d1M7-9lH9xiqdGyJNvzp4angPW5Esc7C5huy_M8I8_DjJK2ZXC2SUYuOFM-Q_5Cw";
+        // "2-S-2"
+        let valid_with_footer = "v2.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAxOS0wMS0wMVQwMDowMDowMCswMDowMCJ9flsZsx_gYCR0N_Ec2QxJFFpvQAs7h9HtKwbVK2n1MJ3Rz-hwe8KUqjnd8FAnIJZ601tp7lGkguU63oGbomhoBw.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
+
+        let untrusted_no_footer = UntrustedToken::try_from(valid_no_footer).unwrap();
+        let untrusted_with_footer = UntrustedToken::try_from(valid_with_footer).unwrap();
+
+        assert_eq!(
+            untrusted_no_footer.get_untrusted_header(),
+            crate::version2::PublicToken::HEADER
+        );
+
+        let msg_len = untrusted_no_footer.get_untrusted_message().len();
+        assert_eq!(
+            &untrusted_no_footer.get_untrusted_message()[..msg_len - 64],
+            "{\"data\":\"this is a signed message\",\"exp\":\"2019-01-01T00:00:00+00:00\"}"
+                .as_bytes()
+        );
+        assert_eq!(untrusted_no_footer.get_untrusted_footer(), &[0u8; 0]);
+
+        assert_eq!(
+            untrusted_with_footer.get_untrusted_header(),
+            crate::version2::PublicToken::HEADER
+        );
+        assert_eq!(
+            &untrusted_with_footer.get_untrusted_message()[..msg_len - 64],
+            "{\"data\":\"this is a signed message\",\"exp\":\"2019-01-01T00:00:00+00:00\"}"
+                .as_bytes()
+        );
+        assert_eq!(
+            untrusted_with_footer.get_untrusted_footer(),
+            "{\"kid\":\"zVhMiPBP9fRf2snEcT7gFTioeA9COcNy9DfgL1W60haN\"}".as_bytes()
+        );
+    }
+
+    #[cfg(feature = "v3")]
+    #[test]
+    fn valid_v3_public() {
+        // "3-S-1"
+        let valid_no_footer = "v3.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9qqEwwrKHKi5lJ7b9MBKc0G4MGZy0ptUiMv3lAUAaz-JY_zjoqBSIxMxhfAoeNYiSyvfUErj76KOPWm1OeNnBPkTSespeSXDGaDfxeIrl3bRrPEIy7tLwLAIsRzsXkfph";
+        // "3-S-2"
+        let valid_with_footer = "v3.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9ZWrbGZ6L0MDK72skosUaS0Dz7wJ_2bMcM6tOxFuCasO9GhwHrvvchqgXQNLQQyWzGC2wkr-VKII71AvkLpC8tJOrzJV1cap9NRwoFzbcXjzMZyxQ0wkshxZxx8ImmNWP.eyJraWQiOiJkWWtJU3lseFFlZWNFY0hFTGZ6Rjg4VVpyd2JMb2xOaUNkcHpVSEd3OVVxbiJ9";
+
+        let untrusted_no_footer = UntrustedToken::try_from(valid_no_footer).unwrap();
+        let untrusted_with_footer = UntrustedToken::try_from(valid_with_footer).unwrap();
+
+        assert_eq!(
+            untrusted_no_footer.get_untrusted_header(),
+            crate::version3::PublicToken::HEADER
+        );
+
+        let msg_len = untrusted_no_footer.get_untrusted_message().len();
+        assert_eq!(
+            &untrusted_no_footer.get_untrusted_message()[..msg_len - 96],
+            "{\"data\":\"this is a signed message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}"
+                .as_bytes()
+        );
+        assert_eq!(untrusted_no_footer.get_untrusted_footer(), &[0u8; 0]);
+
+        assert_eq!(
+            untrusted_with_footer.get_untrusted_header(),
+            crate::version3::PublicToken::HEADER
+        );
+        assert_eq!(
+            &untrusted_with_footer.get_untrusted_message()[..msg_len - 96],
+            "{\"data\":\"this is a signed message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}"
+                .as_bytes()
+        );
+        assert_eq!(
+            untrusted_with_footer.get_untrusted_footer(),
+            "{\"kid\":\"dYkISylxQeecEcHELfzF88UZrwbLolNiCdpzUHGw9Uqn\"}".as_bytes()
+        );
+    }
+
+    #[cfg(feature = "v4")]
+    #[test]
+    fn valid_v4_public() {
+        // "4-S-1"
+        let valid_no_footer = "v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9bg_XBBzds8lTZShVlwwKSgeKpLT3yukTw6JUz3W4h_ExsQV-P0V54zemZDcAxFaSeef1QlXEFtkqxT1ciiQEDA";
+        // "4-S-2"
+        let valid_with_footer = "v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9v3Jt8mx_TdM2ceTGoqwrh4yDFn0XsHvvV_D0DtwQxVrJEBMl0F2caAdgnpKlt4p7xBnx1HcO-SPo8FPp214HDw.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
+
+        let untrusted_no_footer = UntrustedToken::try_from(valid_no_footer).unwrap();
+        let untrusted_with_footer = UntrustedToken::try_from(valid_with_footer).unwrap();
+
+        assert_eq!(
+            untrusted_no_footer.get_untrusted_header(),
+            crate::version4::PublicToken::HEADER
+        );
+
+        let msg_len = untrusted_no_footer.get_untrusted_message().len();
+        assert_eq!(
+            &untrusted_no_footer.get_untrusted_message()[..msg_len - 64],
+            "{\"data\":\"this is a signed message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}"
+                .as_bytes()
+        );
+        assert_eq!(untrusted_no_footer.get_untrusted_footer(), &[0u8; 0]);
+
+        assert_eq!(
+            untrusted_with_footer.get_untrusted_header(),
+            crate::version4::PublicToken::HEADER
+        );
+        assert_eq!(
+            &untrusted_with_footer.get_untrusted_message()[..msg_len - 64],
+            "{\"data\":\"this is a signed message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}"
+                .as_bytes()
+        );
+        assert_eq!(
+            untrusted_with_footer.get_untrusted_footer(),
+            "{\"kid\":\"zVhMiPBP9fRf2snEcT7gFTioeA9COcNy9DfgL1W60haN\"}".as_bytes()
+        );
+    }
+
+    #[cfg(feature = "v4")]
+    #[test]
+    fn valid_v4_local() {
+        // "4-E-1"
+        let valid_no_footer = "v4.local.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAr68PS4AXe7If_ZgesdkUMvSwscFlAl1pk5HC0e8kApeaqMfGo_7OpBnwJOAbY9V7WU6abu74MmcUE8YWAiaArVI8XJ5hOb_4v9RmDkneN0S92dx0OW4pgy7omxgf3S8c3LlQg";
+        // "4-E-5"
+        let valid_with_footer = "v4.local.32VIErrEkmY4JVILovbmfPXKW9wT1OdQepjMTC_MOtjA4kiqw7_tcaOM5GNEcnTxl60WkwMsYXw6FSNb_UdJPXjpzm0KW9ojM5f4O2mRvE2IcweP-PRdoHjd5-RHCiExR1IK6t4x-RMNXtQNbz7FvFZ_G-lFpk5RG3EOrwDL6CgDqcerSQ.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
+
+        let untrusted_no_footer = UntrustedToken::try_from(valid_no_footer).unwrap();
+        let untrusted_with_footer = UntrustedToken::try_from(valid_with_footer).unwrap();
+
+        // Note: We don't test for untrusted message, since it is encrypted.
+        assert_eq!(
+            untrusted_no_footer.get_untrusted_header(),
+            crate::version4::LocalToken::HEADER
+        );
+        assert_eq!(untrusted_no_footer.get_untrusted_footer(), &[0u8; 0]);
+
+        assert_eq!(
+            untrusted_with_footer.get_untrusted_header(),
+            crate::version4::LocalToken::HEADER
+        );
+        assert_eq!(
+            untrusted_with_footer.get_untrusted_footer(),
+            "{\"kid\":\"zVhMiPBP9fRf2snEcT7gFTioeA9COcNy9DfgL1W60haN\"}".as_bytes()
+        );
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,0 +1,73 @@
+use crate::common;
+use crate::errors::Error;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
+
+/// [`UntrustedToken`] can parse PASETO tokens in order to extract individual parts of it.
+///
+/// A use-case for this would be parsing the tokens footer, if this is not known before receiving it. Then,
+/// the footer can be used during verification/decryption of the token itself.
+///
+/// This type should only be used in order to verify the validity of a token.
+///
+/// __WARNING__: Anything returned by this type should be treated as **UNTRUSTED** until the token
+/// has been verified.
+pub struct UntrustedToken {
+    header: String,
+    message: Vec<u8>,
+    footer: Vec<u8>,
+}
+
+impl TryFrom<&str> for UntrustedToken {
+    type Error = Error;
+
+    /// This fails if `value` is not a PASETO token or it has invalid base64 encoding.
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        // Note: The HEADERs are feature-gated and make a complicated if-statement
+        // when used with conditional-compilation. So we used hardcoded here instead.
+        if !value.starts_with("v2.public.")
+            && !value.starts_with("v2.local.")
+            && !value.starts_with("v3.public.")
+            && !value.starts_with("v4.public.")
+            && !value.starts_with("v4.local.")
+        {
+            return Err(Error::TokenFormat);
+        }
+
+        let parts_split = value.split('.').collect::<Vec<&str>>();
+        if parts_split.len() < 3 || parts_split.len() > 4 {
+            return Err(Error::TokenFormat);
+        }
+        let is_footer_present = parts_split.len() == 4;
+
+        Ok(Self {
+            header: format!("{}.{}.", parts_split[0], parts_split[1]),
+            message: common::decode_b64(parts_split[2])?,
+            footer: {
+                if is_footer_present {
+                    common::decode_b64(parts_split[3])?
+                } else {
+                    Vec::<u8>::new()
+                }
+            },
+        })
+    }
+}
+
+impl UntrustedToken {
+    /// Return untrusted header of this [`UntrustedToken].
+    pub fn get_untrusted_header(&self) -> &str {
+        &self.header
+    }
+
+    /// Return untrusted message of this [`UntrustedToken].
+    pub fn get_untrusted_message(&self) -> &[u8] {
+        &self.message
+    }
+
+    /// Return untrusted footer of this [`UntrustedToken].
+    pub fn get_untrusted_footer(&self) -> &[u8] {
+        &self.footer
+    }
+}

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,9 +1,100 @@
+use crate::claims::Claims;
 use crate::common;
 use crate::errors::Error;
+use crate::version::private::Version;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::convert::TryFrom;
+use core::marker::PhantomData;
 
+#[derive(Clone, Debug, PartialEq)]
+/// A [`TrustedToken`] is returned by either a `verify()` or `decrypt()` operation and represents
+/// a validated token.
+///
+/// It represents a authenticated and non-tampered token. It **does not** validate additional things,
+/// such as claims that may be within the token payload itself. These must still be validated separately.
+///
+/// However, using the [`crate::public`] and [`crate::local`] API will automatically handle claims
+/// validation. Any validated claims may be retrieved with [`TrustedToken::payload_claims()`].
+pub struct TrustedToken {
+    header: String,
+    // PASETO requires the payload to be valid JSON in UTF-8, so we say String for UTF-8.
+    payload: String,
+    #[cfg(feature = "std")]
+    // If std is available, we also keep claims as JSON.
+    payload_claims: Option<Claims>,
+    // TODO: See https://github.com/brycx/pasetors/pull/52
+    // TODO: Footer claims, once type is merged, should be available from here like `payload_claims`
+    footer: Vec<u8>,
+    implicit_assert: Vec<u8>,
+}
+
+impl TrustedToken {
+    pub(crate) fn _new(
+        header: &str,
+        payload: &[u8],
+        footer: &[u8],
+        implicit_assert: &[u8],
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            header: header.to_string(),
+            payload: String::from_utf8(payload.to_vec()).map_err(|_| Error::PayloadInvalidUtf8)?,
+            #[cfg(feature = "std")]
+            payload_claims: None,
+            footer: footer.to_vec(),
+            implicit_assert: implicit_assert.to_vec(),
+        })
+    }
+
+    /// Get the header that is used for this token.
+    pub fn header(&self) -> &str {
+        &self.header
+    }
+
+    /// Get the payload that is used for this token.
+    pub fn payload(&self) -> &str {
+        &self.payload
+    }
+
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    /// Return the optional and validated [`Claims`] parsed from the tokens payload.
+    ///
+    /// - `None`: If no [`Claims`] have been parsed or validated.
+    /// - `Some`: If some [`Claims`] have been parsed **AND** validated.
+    ///
+    /// [`Claims`]: crate::claims::Claims
+    pub fn payload_claims(&self) -> Option<&Claims> {
+        debug_assert!(self.payload_claims.is_some());
+        match &self.payload_claims {
+            Some(claims) => Some(claims),
+            None => None,
+        }
+    }
+
+    #[cfg(feature = "std")]
+    /// Set the payload claims **AFTER HAVING VALIDATED THEM**.
+    pub(crate) fn set_payload_claims(&mut self, claims: Claims) {
+        self.payload_claims = Some(claims);
+    }
+
+    /// Get the footer used to create the token.
+    ///
+    /// Empty if `None` was used during creation.
+    pub fn footer(&self) -> &[u8] {
+        &self.footer
+    }
+
+    /// Get the implicit assertion used to create the token.
+    ///
+    /// Empty if `None` was used during creation.
+    /// If token was created using `V2`, then it will always be empty.
+    pub fn implicit_assert(&self) -> &[u8] {
+        &self.implicit_assert
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
 /// [`UntrustedToken`] can parse PASETO tokens in order to extract individual parts of it.
 ///
 /// A use-case for this would be parsing the tokens footer, if this is not known before receiving it. Then,
@@ -13,25 +104,22 @@ use core::convert::TryFrom;
 ///
 /// __WARNING__: Anything returned by this type should be treated as **UNTRUSTED** until the token
 /// has been verified.
-pub struct UntrustedToken {
+pub struct UntrustedToken<V> {
     header: String,
     message: Vec<u8>,
     footer: Vec<u8>,
+    phantom: PhantomData<V>,
 }
 
-impl TryFrom<&str> for UntrustedToken {
+impl<V: Version> TryFrom<&str> for UntrustedToken<V> {
     type Error = Error;
 
     /// This fails if `value` is not a PASETO token or it has invalid base64 encoding.
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        // Note: The HEADERs are feature-gated and make a complicated if-statement
-        // when used with conditional-compilation. So we used hardcoded here instead.
-        if !value.starts_with("v2.public.")
-            && !value.starts_with("v2.local.")
-            && !value.starts_with("v3.public.")
-            && !value.starts_with("v4.public.")
-            && !value.starts_with("v4.local.")
-        {
+        if value.is_empty() {
+            return Err(Error::TokenFormat);
+        }
+        if !value.starts_with(V::public_header()) && !value.starts_with(V::local_header()) {
             return Err(Error::TokenFormat);
         }
 
@@ -39,11 +127,26 @@ impl TryFrom<&str> for UntrustedToken {
         if parts_split.len() < 3 || parts_split.len() > 4 {
             return Err(Error::TokenFormat);
         }
+        if parts_split[2].is_empty() {
+            // Empty payload entirely
+            return Err(Error::TokenFormat);
+        }
+
+        let m_raw = common::decode_b64(parts_split[2])?;
+        if value.starts_with(V::local_header()) && m_raw.len() <= V::LOCAL_NONCE + V::LOCAL_TAG {
+            // Empty payload encrypted. Disallowed by PASETO
+            return Err(Error::TokenFormat);
+        }
+        if value.starts_with(V::public_header()) && m_raw.len() <= V::PUBLIC_SIG {
+            // Empty payload encrypted. Disallowed by PASETO
+            return Err(Error::TokenFormat);
+        }
+
         let is_footer_present = parts_split.len() == 4;
 
         Ok(Self {
             header: format!("{}.{}.", parts_split[0], parts_split[1]),
-            message: common::decode_b64(parts_split[2])?,
+            message: m_raw,
             footer: {
                 if is_footer_present {
                     common::decode_b64(parts_split[3])?
@@ -51,42 +154,207 @@ impl TryFrom<&str> for UntrustedToken {
                     Vec::<u8>::new()
                 }
             },
+            phantom: PhantomData,
         })
     }
 }
 
-impl UntrustedToken {
-    /// Return untrusted header of this [`UntrustedToken].
-    pub fn get_untrusted_header(&self) -> &str {
+impl<V: Version> TryFrom<&String> for UntrustedToken<V> {
+    type Error = Error;
+
+    /// This fails if `value` is not a PASETO token or it has invalid base64 encoding.
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_str())
+    }
+}
+
+impl<V: Version> UntrustedToken<V> {
+    /// Return untrusted header of this [`UntrustedToken`].
+    pub fn untrusted_header(&self) -> &str {
         &self.header
     }
 
-    /// Return untrusted message of this [`UntrustedToken].
-    /// If it is a local token, this is the encrypted message.
+    /// Return untrusted message of this [`UntrustedToken`].
+    /// If it is a local token, this is the encrypted message with nonce and tag.
     /// If it is a public token, the signature is included.
-    pub fn get_untrusted_message(&self) -> &[u8] {
+    pub fn untrusted_message(&self) -> &[u8] {
         &self.message
     }
 
-    /// Return untrusted footer of this [`UntrustedToken].
+    /// Return untrusted payload only of this [`UntrustedToken`]'s message body.
+    /// If it is a local token, this is the encrypted message sans nonce and tag.
+    /// If it is a public token, the signature is not included.
+    pub fn untrusted_payload(&self) -> &[u8] {
+        let h = self.untrusted_header();
+        let m = self.untrusted_message();
+
+        if h.starts_with(V::local_header()) {
+            debug_assert!(m.len() > V::LOCAL_TAG + V::LOCAL_NONCE);
+            // Length have been checked in `TryFrom`
+            &m[V::LOCAL_NONCE..m.len() - V::LOCAL_TAG]
+        } else {
+            debug_assert!(h.starts_with(V::public_header()));
+            debug_assert!(m.len() > V::PUBLIC_SIG);
+            // Length have been checked in `TryFrom`
+            &m[..m.len() - V::PUBLIC_SIG]
+        }
+    }
+
+    /// Return untrusted footer of this [`UntrustedToken`].
     /// Empty if there was no footer in the token.
-    pub fn get_untrusted_footer(&self) -> &[u8] {
+    pub fn untrusted_footer(&self) -> &[u8] {
         &self.footer
     }
 }
 
 #[cfg(test)]
-mod tests {
+mod tests_untrusted {
+    use crate::errors::Error;
     use crate::token::UntrustedToken;
-    use std::convert::TryFrom;
+    use crate::version::private::Version;
+    use crate::{V2, V3, V4};
+    use core::convert::TryFrom;
+
+    const V2_PUBLIC_TOKEN: &'static str = "v2.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAxOS0wMS0wMVQwMDowMDowMCswMDowMCJ9flsZsx_gYCR0N_Ec2QxJFFpvQAs7h9HtKwbVK2n1MJ3Rz-hwe8KUqjnd8FAnIJZ601tp7lGkguU63oGbomhoBw.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
+    const V2_LOCAL_TOKEN: &'static str = "v2.local.5K4SCXNhItIhyNuVIZcwrdtaDKiyF81-eWHScuE0idiVqCo72bbjo07W05mqQkhLZdVbxEa5I_u5sgVk1QLkcWEcOSlLHwNpCkvmGGlbCdNExn6Qclw3qTKIIl5-zSLIrxZqOLwcFLYbVK1SrQ.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
+    const V3_PUBLIC_TOKEN: &'static str = "v3.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9ZWrbGZ6L0MDK72skosUaS0Dz7wJ_2bMcM6tOxFuCasO9GhwHrvvchqgXQNLQQyWzGC2wkr-VKII71AvkLpC8tJOrzJV1cap9NRwoFzbcXjzMZyxQ0wkshxZxx8ImmNWP.eyJraWQiOiJkWWtJU3lseFFlZWNFY0hFTGZ6Rjg4VVpyd2JMb2xOaUNkcHpVSEd3OVVxbiJ9";
+    const V4_PUBLIC_TOKEN: &'static str = "v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9v3Jt8mx_TdM2ceTGoqwrh4yDFn0XsHvvV_D0DtwQxVrJEBMl0F2caAdgnpKlt4p7xBnx1HcO-SPo8FPp214HDw.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
+    const V4_LOCAL_TOKEN: &'static str = "v4.local.32VIErrEkmY4JVILovbmfPXKW9wT1OdQepjMTC_MOtjA4kiqw7_tcaOM5GNEcnTxl60WkwMsYXw6FSNb_UdJPXjpzm0KW9ojM5f4O2mRvE2IcweP-PRdoHjd5-RHCiExR1IK6t4x-RMNXtQNbz7FvFZ_G-lFpk5RG3EOrwDL6CgDqcerSQ.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
+
+    const TOKEN_LIST: [&'static str; 5] = [
+        V2_PUBLIC_TOKEN,
+        V2_LOCAL_TOKEN,
+        V3_PUBLIC_TOKEN,
+        V4_LOCAL_TOKEN,
+        V4_PUBLIC_TOKEN,
+    ];
+
+    fn test_untrusted_parse_fails(invalid: &str, expected_err: Error) {
+        if invalid.starts_with(V2::local_header()) || invalid.starts_with(V2::public_header()) {
+            assert_eq!(
+                UntrustedToken::<V2>::try_from(invalid).unwrap_err(),
+                expected_err
+            );
+        }
+        if invalid.starts_with(V3::public_header()) {
+            assert_eq!(
+                UntrustedToken::<V3>::try_from(invalid).unwrap_err(),
+                expected_err
+            );
+        }
+        if invalid.starts_with(V4::local_header()) || invalid.starts_with(V4::public_header()) {
+            assert_eq!(
+                UntrustedToken::<V4>::try_from(invalid).unwrap_err(),
+                expected_err
+            );
+        }
+    }
 
     #[test]
-    fn invalid_tokens() {
-        assert!(UntrustedToken::try_from("v2.public.AAAAA%%%").is_err());
-        assert!(UntrustedToken::try_from("v2.depends.AAAAAAAA").is_err());
-        assert!(UntrustedToken::try_from("v999.public.AAAAA%%%").is_err());
-        assert!(UntrustedToken::try_from("v2.").is_err());
-        assert!(UntrustedToken::try_from("v2.public").is_err());
+    fn empty_string() {
+        assert_eq!(
+            UntrustedToken::<V2>::try_from("").unwrap_err(),
+            Error::TokenFormat
+        );
+        assert_eq!(
+            UntrustedToken::<V3>::try_from("").unwrap_err(),
+            Error::TokenFormat
+        );
+        assert_eq!(
+            UntrustedToken::<V4>::try_from("").unwrap_err(),
+            Error::TokenFormat
+        );
+    }
+
+    #[test]
+    fn no_separators() {
+        for token in TOKEN_LIST {
+            let split = token.split('.').collect::<Vec<&str>>();
+            let invalid: String = split.iter().map(|x| *x).collect();
+
+            test_untrusted_parse_fails(&invalid, Error::TokenFormat);
+        }
+    }
+
+    #[test]
+    // NOTE: See https://github.com/paseto-standard/paseto-spec/issues/17
+    fn missing_payload() {
+        for token in TOKEN_LIST {
+            let split = token.split('.').collect::<Vec<&str>>();
+            let invalid: String = format!("{}.{}..{}", split[0], split[1], split[3]);
+
+            test_untrusted_parse_fails(&invalid, Error::TokenFormat);
+        }
+    }
+
+    #[test]
+    fn extra_after_footer() {
+        for token in TOKEN_LIST {
+            let mut invalid = token.to_string();
+            invalid.extend(".shouldNotBeHere".chars());
+
+            test_untrusted_parse_fails(&invalid, Error::TokenFormat);
+        }
+    }
+
+    #[test]
+    fn invalid_header() {
+        // Invalid version
+        assert_eq!(
+            UntrustedToken::<V2>::try_from(&V2_PUBLIC_TOKEN.replace("v2", "")).unwrap_err(),
+            Error::TokenFormat
+        );
+        assert_eq!(
+            UntrustedToken::<V2>::try_from(&V2_LOCAL_TOKEN.replace("v2", "")).unwrap_err(),
+            Error::TokenFormat
+        );
+        assert_eq!(
+            UntrustedToken::<V3>::try_from(&V3_PUBLIC_TOKEN.replace("v3", "")).unwrap_err(),
+            Error::TokenFormat
+        );
+        assert_eq!(
+            UntrustedToken::<V4>::try_from(&V4_LOCAL_TOKEN.replace("v4", "")).unwrap_err(),
+            Error::TokenFormat
+        );
+        assert_eq!(
+            UntrustedToken::<V4>::try_from(&V4_PUBLIC_TOKEN.replace("v4", "")).unwrap_err(),
+            Error::TokenFormat
+        );
+
+        // Invalid purpose
+        assert_eq!(
+            UntrustedToken::<V2>::try_from(&V2_PUBLIC_TOKEN.replace("public", "")).unwrap_err(),
+            Error::TokenFormat
+        );
+        assert_eq!(
+            UntrustedToken::<V2>::try_from(&V2_LOCAL_TOKEN.replace("local", "")).unwrap_err(),
+            Error::TokenFormat
+        );
+        assert_eq!(
+            UntrustedToken::<V3>::try_from(&V3_PUBLIC_TOKEN.replace("public", "")).unwrap_err(),
+            Error::TokenFormat
+        );
+        assert_eq!(
+            UntrustedToken::<V4>::try_from(&V4_LOCAL_TOKEN.replace("local", "")).unwrap_err(),
+            Error::TokenFormat
+        );
+        assert_eq!(
+            UntrustedToken::<V4>::try_from(&V4_PUBLIC_TOKEN.replace("public", "")).unwrap_err(),
+            Error::TokenFormat
+        );
+    }
+
+    #[test]
+    fn invalid_base64() {
+        for token in TOKEN_LIST {
+            let split = token.split('.').collect::<Vec<&str>>();
+
+            let invalid: String = format!("{}.{}.{}!.{}", split[0], split[1], split[2], split[3]);
+            test_untrusted_parse_fails(&invalid, Error::Base64Decoding);
+
+            let invalid: String = format!("{}.{}.{}.{}!", split[0], split[1], split[2], split[3]);
+            test_untrusted_parse_fails(&invalid, Error::Base64Decoding);
+        }
     }
 
     #[cfg(feature = "v2")]
@@ -97,22 +365,22 @@ mod tests {
         // "2-E-5"
         let valid_with_footer = "v2.local.5K4SCXNhItIhyNuVIZcwrdtaDKiyF81-eWHScuE0idiVqCo72bbjo07W05mqQkhLZdVbxEa5I_u5sgVk1QLkcWEcOSlLHwNpCkvmGGlbCdNExn6Qclw3qTKIIl5-zSLIrxZqOLwcFLYbVK1SrQ.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
 
-        let untrusted_no_footer = UntrustedToken::try_from(valid_no_footer).unwrap();
-        let untrusted_with_footer = UntrustedToken::try_from(valid_with_footer).unwrap();
+        let untrusted_no_footer = UntrustedToken::<V2>::try_from(valid_no_footer).unwrap();
+        let untrusted_with_footer = UntrustedToken::<V2>::try_from(valid_with_footer).unwrap();
 
         // Note: We don't test for untrusted message, since it is encrypted.
         assert_eq!(
-            untrusted_no_footer.get_untrusted_header(),
+            untrusted_no_footer.untrusted_header(),
             crate::version2::LocalToken::HEADER
         );
-        assert_eq!(untrusted_no_footer.get_untrusted_footer(), &[0u8; 0]);
+        assert_eq!(untrusted_no_footer.untrusted_footer(), &[0u8; 0]);
 
         assert_eq!(
-            untrusted_with_footer.get_untrusted_header(),
+            untrusted_with_footer.untrusted_header(),
             crate::version2::LocalToken::HEADER
         );
         assert_eq!(
-            untrusted_with_footer.get_untrusted_footer(),
+            untrusted_with_footer.untrusted_footer(),
             "{\"kid\":\"zVhMiPBP9fRf2snEcT7gFTioeA9COcNy9DfgL1W60haN\"}".as_bytes()
         );
     }
@@ -125,33 +393,32 @@ mod tests {
         // "2-S-2"
         let valid_with_footer = "v2.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAxOS0wMS0wMVQwMDowMDowMCswMDowMCJ9flsZsx_gYCR0N_Ec2QxJFFpvQAs7h9HtKwbVK2n1MJ3Rz-hwe8KUqjnd8FAnIJZ601tp7lGkguU63oGbomhoBw.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
 
-        let untrusted_no_footer = UntrustedToken::try_from(valid_no_footer).unwrap();
-        let untrusted_with_footer = UntrustedToken::try_from(valid_with_footer).unwrap();
+        let untrusted_no_footer = UntrustedToken::<V2>::try_from(valid_no_footer).unwrap();
+        let untrusted_with_footer = UntrustedToken::<V2>::try_from(valid_with_footer).unwrap();
 
         assert_eq!(
-            untrusted_no_footer.get_untrusted_header(),
+            untrusted_no_footer.untrusted_header(),
             crate::version2::PublicToken::HEADER
         );
 
-        let msg_len = untrusted_no_footer.get_untrusted_message().len();
         assert_eq!(
-            &untrusted_no_footer.get_untrusted_message()[..msg_len - 64],
+            untrusted_no_footer.untrusted_payload(),
             "{\"data\":\"this is a signed message\",\"exp\":\"2019-01-01T00:00:00+00:00\"}"
                 .as_bytes()
         );
-        assert_eq!(untrusted_no_footer.get_untrusted_footer(), &[0u8; 0]);
+        assert_eq!(untrusted_no_footer.untrusted_footer(), &[0u8; 0]);
 
         assert_eq!(
-            untrusted_with_footer.get_untrusted_header(),
+            untrusted_with_footer.untrusted_header(),
             crate::version2::PublicToken::HEADER
         );
         assert_eq!(
-            &untrusted_with_footer.get_untrusted_message()[..msg_len - 64],
+            untrusted_with_footer.untrusted_payload(),
             "{\"data\":\"this is a signed message\",\"exp\":\"2019-01-01T00:00:00+00:00\"}"
                 .as_bytes()
         );
         assert_eq!(
-            untrusted_with_footer.get_untrusted_footer(),
+            untrusted_with_footer.untrusted_footer(),
             "{\"kid\":\"zVhMiPBP9fRf2snEcT7gFTioeA9COcNy9DfgL1W60haN\"}".as_bytes()
         );
     }
@@ -164,33 +431,32 @@ mod tests {
         // "3-S-2"
         let valid_with_footer = "v3.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9ZWrbGZ6L0MDK72skosUaS0Dz7wJ_2bMcM6tOxFuCasO9GhwHrvvchqgXQNLQQyWzGC2wkr-VKII71AvkLpC8tJOrzJV1cap9NRwoFzbcXjzMZyxQ0wkshxZxx8ImmNWP.eyJraWQiOiJkWWtJU3lseFFlZWNFY0hFTGZ6Rjg4VVpyd2JMb2xOaUNkcHpVSEd3OVVxbiJ9";
 
-        let untrusted_no_footer = UntrustedToken::try_from(valid_no_footer).unwrap();
-        let untrusted_with_footer = UntrustedToken::try_from(valid_with_footer).unwrap();
+        let untrusted_no_footer = UntrustedToken::<V3>::try_from(valid_no_footer).unwrap();
+        let untrusted_with_footer = UntrustedToken::<V3>::try_from(valid_with_footer).unwrap();
 
         assert_eq!(
-            untrusted_no_footer.get_untrusted_header(),
+            untrusted_no_footer.untrusted_header(),
             crate::version3::PublicToken::HEADER
         );
 
-        let msg_len = untrusted_no_footer.get_untrusted_message().len();
         assert_eq!(
-            &untrusted_no_footer.get_untrusted_message()[..msg_len - 96],
+            untrusted_no_footer.untrusted_payload(),
             "{\"data\":\"this is a signed message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}"
                 .as_bytes()
         );
-        assert_eq!(untrusted_no_footer.get_untrusted_footer(), &[0u8; 0]);
+        assert_eq!(untrusted_no_footer.untrusted_footer(), &[0u8; 0]);
 
         assert_eq!(
-            untrusted_with_footer.get_untrusted_header(),
+            untrusted_with_footer.untrusted_header(),
             crate::version3::PublicToken::HEADER
         );
         assert_eq!(
-            &untrusted_with_footer.get_untrusted_message()[..msg_len - 96],
+            untrusted_with_footer.untrusted_payload(),
             "{\"data\":\"this is a signed message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}"
                 .as_bytes()
         );
         assert_eq!(
-            untrusted_with_footer.get_untrusted_footer(),
+            untrusted_with_footer.untrusted_footer(),
             "{\"kid\":\"dYkISylxQeecEcHELfzF88UZrwbLolNiCdpzUHGw9Uqn\"}".as_bytes()
         );
     }
@@ -203,33 +469,32 @@ mod tests {
         // "4-S-2"
         let valid_with_footer = "v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9v3Jt8mx_TdM2ceTGoqwrh4yDFn0XsHvvV_D0DtwQxVrJEBMl0F2caAdgnpKlt4p7xBnx1HcO-SPo8FPp214HDw.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
 
-        let untrusted_no_footer = UntrustedToken::try_from(valid_no_footer).unwrap();
-        let untrusted_with_footer = UntrustedToken::try_from(valid_with_footer).unwrap();
+        let untrusted_no_footer = UntrustedToken::<V4>::try_from(valid_no_footer).unwrap();
+        let untrusted_with_footer = UntrustedToken::<V4>::try_from(valid_with_footer).unwrap();
 
         assert_eq!(
-            untrusted_no_footer.get_untrusted_header(),
+            untrusted_no_footer.untrusted_header(),
             crate::version4::PublicToken::HEADER
         );
 
-        let msg_len = untrusted_no_footer.get_untrusted_message().len();
         assert_eq!(
-            &untrusted_no_footer.get_untrusted_message()[..msg_len - 64],
+            untrusted_no_footer.untrusted_payload(),
             "{\"data\":\"this is a signed message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}"
                 .as_bytes()
         );
-        assert_eq!(untrusted_no_footer.get_untrusted_footer(), &[0u8; 0]);
+        assert_eq!(untrusted_no_footer.untrusted_footer(), &[0u8; 0]);
 
         assert_eq!(
-            untrusted_with_footer.get_untrusted_header(),
+            untrusted_with_footer.untrusted_header(),
             crate::version4::PublicToken::HEADER
         );
         assert_eq!(
-            &untrusted_with_footer.get_untrusted_message()[..msg_len - 64],
+            untrusted_with_footer.untrusted_payload(),
             "{\"data\":\"this is a signed message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}"
                 .as_bytes()
         );
         assert_eq!(
-            untrusted_with_footer.get_untrusted_footer(),
+            untrusted_with_footer.untrusted_footer(),
             "{\"kid\":\"zVhMiPBP9fRf2snEcT7gFTioeA9COcNy9DfgL1W60haN\"}".as_bytes()
         );
     }
@@ -242,23 +507,37 @@ mod tests {
         // "4-E-5"
         let valid_with_footer = "v4.local.32VIErrEkmY4JVILovbmfPXKW9wT1OdQepjMTC_MOtjA4kiqw7_tcaOM5GNEcnTxl60WkwMsYXw6FSNb_UdJPXjpzm0KW9ojM5f4O2mRvE2IcweP-PRdoHjd5-RHCiExR1IK6t4x-RMNXtQNbz7FvFZ_G-lFpk5RG3EOrwDL6CgDqcerSQ.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
 
-        let untrusted_no_footer = UntrustedToken::try_from(valid_no_footer).unwrap();
-        let untrusted_with_footer = UntrustedToken::try_from(valid_with_footer).unwrap();
+        let untrusted_no_footer = UntrustedToken::<V4>::try_from(valid_no_footer).unwrap();
+        let untrusted_with_footer = UntrustedToken::<V4>::try_from(valid_with_footer).unwrap();
 
         // Note: We don't test for untrusted message, since it is encrypted.
         assert_eq!(
-            untrusted_no_footer.get_untrusted_header(),
+            untrusted_no_footer.untrusted_header(),
             crate::version4::LocalToken::HEADER
         );
-        assert_eq!(untrusted_no_footer.get_untrusted_footer(), &[0u8; 0]);
+        assert_eq!(untrusted_no_footer.untrusted_footer(), &[0u8; 0]);
 
         assert_eq!(
-            untrusted_with_footer.get_untrusted_header(),
+            untrusted_with_footer.untrusted_header(),
             crate::version4::LocalToken::HEADER
         );
         assert_eq!(
-            untrusted_with_footer.get_untrusted_footer(),
+            untrusted_with_footer.untrusted_footer(),
             "{\"kid\":\"zVhMiPBP9fRf2snEcT7gFTioeA9COcNy9DfgL1W60haN\"}".as_bytes()
         );
+    }
+
+    #[test]
+    fn local_token_nonce_tag_no_payload_v4() {
+        assert!(UntrustedToken::<V4>::try_from(
+            "v4.local.444444bbbbb444444444bbb444444bbb44444444444444888888888888888cJJbbb44444444",
+        )
+        .is_err());
+    }
+    #[test]
+    fn local_token_nonce_tag_no_payload_v3() {
+        assert!(UntrustedToken::<V3>::try_from(
+            "v3.local.oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo",
+        ).is_err());
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,3 +1,5 @@
+use crate::alloc::string::ToString;
+#[cfg(feature = "std")]
 use crate::claims::Claims;
 use crate::common;
 use crate::errors::Error;

--- a/src/token.rs
+++ b/src/token.rs
@@ -121,7 +121,7 @@ impl<V: Version> TryFrom<&str> for UntrustedToken<V> {
         if value.is_empty() {
             return Err(Error::TokenFormat);
         }
-        if !value.starts_with(V::public_header()) && !value.starts_with(V::local_header()) {
+        if !value.starts_with(V::PUBLIC_HEADER) && !value.starts_with(V::LOCAL_HEADER) {
             return Err(Error::TokenFormat);
         }
 
@@ -135,11 +135,11 @@ impl<V: Version> TryFrom<&str> for UntrustedToken<V> {
         }
 
         let m_raw = common::decode_b64(parts_split[2])?;
-        if value.starts_with(V::local_header()) && m_raw.len() <= V::LOCAL_NONCE + V::LOCAL_TAG {
+        if value.starts_with(V::LOCAL_HEADER) && m_raw.len() <= V::LOCAL_NONCE + V::LOCAL_TAG {
             // Empty payload encrypted. Disallowed by PASETO
             return Err(Error::TokenFormat);
         }
-        if value.starts_with(V::public_header()) && m_raw.len() <= V::PUBLIC_SIG {
+        if value.starts_with(V::PUBLIC_HEADER) && m_raw.len() <= V::PUBLIC_SIG {
             // Empty payload encrypted. Disallowed by PASETO
             return Err(Error::TokenFormat);
         }
@@ -190,12 +190,12 @@ impl<V: Version> UntrustedToken<V> {
         let h = self.untrusted_header();
         let m = self.untrusted_message();
 
-        if h.starts_with(V::local_header()) {
+        if h.starts_with(V::LOCAL_HEADER) {
             debug_assert!(m.len() > V::LOCAL_TAG + V::LOCAL_NONCE);
             // Length have been checked in `TryFrom`
             &m[V::LOCAL_NONCE..m.len() - V::LOCAL_TAG]
         } else {
-            debug_assert!(h.starts_with(V::public_header()));
+            debug_assert!(h.starts_with(V::PUBLIC_HEADER));
             debug_assert!(m.len() > V::PUBLIC_SIG);
             // Length have been checked in `TryFrom`
             &m[..m.len() - V::PUBLIC_SIG]
@@ -232,19 +232,19 @@ mod tests_untrusted {
     ];
 
     fn test_untrusted_parse_fails(invalid: &str, expected_err: Error) {
-        if invalid.starts_with(V2::local_header()) || invalid.starts_with(V2::public_header()) {
+        if invalid.starts_with(V2::LOCAL_HEADER) || invalid.starts_with(V2::PUBLIC_HEADER) {
             assert_eq!(
                 UntrustedToken::<V2>::try_from(invalid).unwrap_err(),
                 expected_err
             );
         }
-        if invalid.starts_with(V3::public_header()) {
+        if invalid.starts_with(V3::PUBLIC_HEADER) {
             assert_eq!(
                 UntrustedToken::<V3>::try_from(invalid).unwrap_err(),
                 expected_err
             );
         }
-        if invalid.starts_with(V4::local_header()) || invalid.starts_with(V4::public_header()) {
+        if invalid.starts_with(V4::LOCAL_HEADER) || invalid.starts_with(V4::PUBLIC_HEADER) {
             assert_eq!(
                 UntrustedToken::<V4>::try_from(invalid).unwrap_err(),
                 expected_err

--- a/src/version.rs
+++ b/src/version.rs
@@ -20,6 +20,10 @@ pub(crate) mod private {
         const LOCAL_NONCE: usize;
         /// Size of the authentication tag for a local token.
         const LOCAL_TAG: usize;
+        /// Header for a public token for this version.
+        const PUBLIC_HEADER: &'static str;
+        /// Header for a local token for this version.
+        const LOCAL_HEADER: &'static str;
 
         /// Validate bytes for a `local` key of a given version.
         fn validate_local_key(key_bytes: &[u8]) -> Result<(), Error>;
@@ -27,10 +31,6 @@ pub(crate) mod private {
         fn validate_secret_key(key_bytes: &[u8]) -> Result<(), Error>;
         /// Validate bytes for a public `local` key of a given version.
         fn validate_public_key(key_bytes: &[u8]) -> Result<(), Error>;
-        /// Get the header of a public token for this version.
-        fn public_header() -> &'static str;
-        /// Get the header of a local token for this version.
-        fn local_header() -> &'static str;
     }
 }
 
@@ -53,6 +53,8 @@ impl Version for V2 {
     const PUBLIC_SIG: usize = 64;
     const LOCAL_NONCE: usize = 24;
     const LOCAL_TAG: usize = 16;
+    const PUBLIC_HEADER: &'static str = "v2.public.";
+    const LOCAL_HEADER: &'static str = "v2.local.";
 
     fn validate_local_key(key_bytes: &[u8]) -> Result<(), Error> {
         if key_bytes.len() != Self::LOCAL_KEY {
@@ -69,14 +71,6 @@ impl Version for V2 {
     fn validate_public_key(key_bytes: &[u8]) -> Result<(), Error> {
         Self::validate_secret_key(key_bytes)
     }
-
-    fn public_header() -> &'static str {
-        "v2.public."
-    }
-
-    fn local_header() -> &'static str {
-        "v2.local."
-    }
 }
 
 impl Version for V3 {
@@ -86,6 +80,8 @@ impl Version for V3 {
     const PUBLIC_SIG: usize = 96;
     const LOCAL_NONCE: usize = 32;
     const LOCAL_TAG: usize = 48;
+    const PUBLIC_HEADER: &'static str = "v3.public.";
+    const LOCAL_HEADER: &'static str = "v3.local.";
 
     fn validate_local_key(_key_bytes: &[u8]) -> Result<(), Error> {
         unimplemented!();
@@ -109,14 +105,6 @@ impl Version for V3 {
 
         Ok(())
     }
-
-    fn public_header() -> &'static str {
-        "v3.public."
-    }
-
-    fn local_header() -> &'static str {
-        "v3.local."
-    }
 }
 
 impl Version for V4 {
@@ -126,6 +114,8 @@ impl Version for V4 {
     const PUBLIC_SIG: usize = V2::PUBLIC_SIG;
     const LOCAL_NONCE: usize = 32;
     const LOCAL_TAG: usize = 32;
+    const PUBLIC_HEADER: &'static str = "v4.public.";
+    const LOCAL_HEADER: &'static str = "v4.local.";
 
     fn validate_local_key(key_bytes: &[u8]) -> Result<(), Error> {
         V2::validate_local_key(key_bytes)
@@ -137,13 +127,5 @@ impl Version for V4 {
 
     fn validate_public_key(key_bytes: &[u8]) -> Result<(), Error> {
         V2::validate_public_key(key_bytes)
-    }
-
-    fn public_header() -> &'static str {
-        "v4.public."
-    }
-
-    fn local_header() -> &'static str {
-        "v4.local."
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,149 @@
+use crate::errors::Error;
+use private::Version;
+
+pub(crate) mod private {
+    use super::Error;
+
+    // Inside private module to prevent users from implementing this themself.
+
+    /// A given version must implement validation logic in terms of both itself and the kind of key.
+    pub trait Version {
+        /// Size for a `local` key.
+        const LOCAL_KEY: usize;
+        /// Size for a secret `public` key.
+        const SECRET_KEY: usize;
+        /// Size for a public `public` key.
+        const PUBLIC_KEY: usize;
+        /// Size of the signature for a public token.
+        const PUBLIC_SIG: usize;
+        /// Size of the nonce for a local token.
+        const LOCAL_NONCE: usize;
+        /// Size of the authentication tag for a local token.
+        const LOCAL_TAG: usize;
+
+        /// Validate bytes for a `local` key of a given version.
+        fn validate_local_key(key_bytes: &[u8]) -> Result<(), Error>;
+        /// Validate bytes for a secret `public` key of a given version.
+        fn validate_secret_key(key_bytes: &[u8]) -> Result<(), Error>;
+        /// Validate bytes for a public `local` key of a given version.
+        fn validate_public_key(key_bytes: &[u8]) -> Result<(), Error>;
+        /// Get the header of a public token for this version.
+        fn public_header() -> &'static str;
+        /// Get the header of a local token for this version.
+        fn local_header() -> &'static str;
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+/// Version 2 of the PASETO spec.
+pub struct V2;
+
+#[derive(Debug, PartialEq, Clone)]
+/// Version 3 of the PASETO spec.
+pub struct V3;
+
+#[derive(Debug, PartialEq, Clone)]
+/// Version 4 of the PASETO spec.
+pub struct V4;
+
+impl Version for V2 {
+    const LOCAL_KEY: usize = 32;
+    const SECRET_KEY: usize = 32;
+    const PUBLIC_KEY: usize = 32;
+    const PUBLIC_SIG: usize = 64;
+    const LOCAL_NONCE: usize = 24;
+    const LOCAL_TAG: usize = 16;
+
+    fn validate_local_key(key_bytes: &[u8]) -> Result<(), Error> {
+        if key_bytes.len() != Self::LOCAL_KEY {
+            return Err(Error::Key);
+        }
+
+        Ok(())
+    }
+
+    fn validate_secret_key(key_bytes: &[u8]) -> Result<(), Error> {
+        Self::validate_local_key(key_bytes)
+    }
+
+    fn validate_public_key(key_bytes: &[u8]) -> Result<(), Error> {
+        Self::validate_secret_key(key_bytes)
+    }
+
+    fn public_header() -> &'static str {
+        "v2.public."
+    }
+
+    fn local_header() -> &'static str {
+        "v2.local."
+    }
+}
+
+impl Version for V3 {
+    const LOCAL_KEY: usize = 32;
+    const SECRET_KEY: usize = 48;
+    const PUBLIC_KEY: usize = 49;
+    const PUBLIC_SIG: usize = 96;
+    const LOCAL_NONCE: usize = 32;
+    const LOCAL_TAG: usize = 48;
+
+    fn validate_local_key(_key_bytes: &[u8]) -> Result<(), Error> {
+        unimplemented!();
+    }
+
+    fn validate_secret_key(key_bytes: &[u8]) -> Result<(), Error> {
+        if key_bytes.len() != Self::SECRET_KEY {
+            return Err(Error::Key);
+        }
+
+        Ok(())
+    }
+
+    fn validate_public_key(key_bytes: &[u8]) -> Result<(), Error> {
+        if key_bytes.len() != Self::PUBLIC_KEY {
+            return Err(Error::Key);
+        }
+        if key_bytes[0] != 0x02 && key_bytes[0] != 0x03 {
+            return Err(Error::Key);
+        }
+
+        Ok(())
+    }
+
+    fn public_header() -> &'static str {
+        "v3.public."
+    }
+
+    fn local_header() -> &'static str {
+        "v3.local."
+    }
+}
+
+impl Version for V4 {
+    const LOCAL_KEY: usize = V2::LOCAL_KEY;
+    const SECRET_KEY: usize = V2::SECRET_KEY;
+    const PUBLIC_KEY: usize = V2::PUBLIC_KEY;
+    const PUBLIC_SIG: usize = V2::PUBLIC_SIG;
+    const LOCAL_NONCE: usize = 32;
+    const LOCAL_TAG: usize = 32;
+
+    fn validate_local_key(key_bytes: &[u8]) -> Result<(), Error> {
+        V2::validate_local_key(key_bytes)
+    }
+
+    fn validate_secret_key(key_bytes: &[u8]) -> Result<(), Error> {
+        V2::validate_secret_key(key_bytes)
+    }
+
+    fn validate_public_key(key_bytes: &[u8]) -> Result<(), Error> {
+        V2::validate_public_key(key_bytes)
+    }
+
+    fn public_header() -> &'static str {
+        "v4.public."
+    }
+
+    fn local_header() -> &'static str {
+        "v4.local."
+    }
+}

--- a/src/version2.rs
+++ b/src/version2.rs
@@ -318,7 +318,7 @@ mod tests {
     use super::*;
     use crate::keys::{AsymmetricKeyPair, Generate};
     use crate::token::UntrustedToken;
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     const TEST_SK_BYTES: [u8; 32] = [
         180, 203, 251, 67, 223, 76, 226, 16, 114, 125, 149, 62, 74, 113, 51, 7, 250, 25, 187, 125,

--- a/src/version2.rs
+++ b/src/version2.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(docsrs, doc(cfg(feature = "v2")))]
 
-use crate::common::{encode_b64, validate_format_untrusted_token};
+use crate::common::{encode_b64, validate_footer_untrusted_token};
 use crate::errors::Error;
 use crate::keys::{AsymmetricPublicKey, AsymmetricSecretKey, SymmetricKey};
 use crate::token::{Local, Public, TrustedToken, UntrustedToken};
@@ -63,7 +63,7 @@ impl PublicToken {
         token: &UntrustedToken<Public, V2>,
         footer: Option<&[u8]>,
     ) -> Result<TrustedToken, Error> {
-        validate_format_untrusted_token(Self::HEADER, token, footer)?;
+        validate_footer_untrusted_token(token, footer)?;
 
         let f = token.untrusted_footer();
         let sm = token.untrusted_message();
@@ -163,7 +163,7 @@ impl LocalToken {
         token: &UntrustedToken<Local, V2>,
         footer: Option<&[u8]>,
     ) -> Result<TrustedToken, Error> {
-        validate_format_untrusted_token(Self::HEADER, token, footer)?;
+        validate_footer_untrusted_token(token, footer)?;
 
         let f = token.untrusted_footer();
         let nc = token.untrusted_message();

--- a/src/version2.rs
+++ b/src/version2.rs
@@ -1,13 +1,19 @@
 #![cfg_attr(docsrs, doc(cfg(feature = "v2")))]
 
+use crate::common::{encode_b64, validate_format_untrusted_token};
+use crate::errors::Error;
+use crate::keys::{AsymmetricPublicKey, AsymmetricSecretKey, SymmetricKey};
+use crate::token::{TrustedToken, UntrustedToken};
+use crate::version::private::Version;
+use crate::{pae, V2};
 use alloc::string::String;
 use alloc::vec::Vec;
+use ed25519_compact::{KeyPair, PublicKey, Signature};
+use orion::hazardous::aead::xchacha20poly1305::*;
+use orion::hazardous::mac::blake2b;
+use orion::hazardous::mac::poly1305::POLY1305_OUTSIZE;
+use orion::hazardous::stream::xchacha20::XCHACHA_NONCESIZE;
 use zeroize::Zeroizing;
-
-use crate::common::{decode_b64, encode_b64, validate_format_footer};
-use crate::errors::Error;
-use crate::keys::{AsymmetricPublicKey, AsymmetricSecretKey, SymmetricKey, V2};
-use crate::pae;
 
 /// PASETO v2 public tokens.
 pub struct PublicToken;
@@ -23,8 +29,6 @@ impl PublicToken {
         message: &[u8],
         footer: Option<&[u8]>,
     ) -> Result<String, Error> {
-        use ed25519_compact::KeyPair;
-
         if message.is_empty() {
             return Err(Error::EmptyPayload);
         }
@@ -51,37 +55,30 @@ impl PublicToken {
     }
 
     /// Verify a public token.
+    ///
+    /// If `footer.is_none()`, then it will be validated but not compared to a known value.
+    /// If `footer.is_some()`, then it will be validated AND compared to the known value.
     pub fn verify(
         public_key: &AsymmetricPublicKey<V2>,
-        token: &str,
+        token: &UntrustedToken<V2>,
         footer: Option<&[u8]>,
-    ) -> Result<(), Error> {
-        use ed25519_compact::{PublicKey, Signature};
+    ) -> Result<TrustedToken, Error> {
+        validate_format_untrusted_token(Self::HEADER, token, footer)?;
 
-        if token.is_empty() {
-            return Err(Error::EmptyPayload);
-        }
-
-        let f = footer.unwrap_or(&[]);
-
-        let parts_split = validate_format_footer(Self::HEADER, token, f)?;
-        let sm = decode_b64(parts_split[2])?;
-        if sm.len() < ed25519_compact::Signature::BYTES {
-            return Err(Error::TokenFormat);
-        }
-
-        let m = sm[..(sm.len() - ed25519_compact::Signature::BYTES)].as_ref();
-        let s = sm[m.len()..m.len() + ed25519_compact::Signature::BYTES].as_ref();
+        let f = token.untrusted_footer();
+        let sm = token.untrusted_message();
+        let m = token.untrusted_payload();
+        let s = sm[m.len()..m.len() + V2::PUBLIC_SIG].as_ref();
 
         let m2 = pae::pae(&[Self::HEADER.as_bytes(), m, f])?;
         let pk: PublicKey = PublicKey::from_slice(public_key.as_bytes()).map_err(|_| Error::Key)?;
 
-        debug_assert!(s.len() == ed25519_compact::Signature::BYTES);
+        debug_assert!(s.len() == V2::PUBLIC_SIG);
         // If the below fails, it is an invalid signature.
         let sig = Signature::from_slice(s).map_err(|_| Error::TokenValidation)?;
 
         if pk.verify(m2, &sig).is_ok() {
-            Ok(())
+            TrustedToken::_new(Self::HEADER, m, f, &[])
         } else {
             Err(Error::TokenValidation)
         }
@@ -103,11 +100,6 @@ impl LocalToken {
         message: &[u8],
         footer: Option<&[u8]>,
     ) -> Result<String, Error> {
-        use orion::hazardous::aead::xchacha20poly1305::*;
-        use orion::hazardous::mac::blake2b;
-        use orion::hazardous::mac::poly1305::POLY1305_OUTSIZE;
-        use orion::hazardous::stream::xchacha20::XCHACHA_NONCESIZE;
-
         debug_assert!(nonce_key_bytes.len() == XCHACHA_NONCESIZE);
 
         // Safe unwrap()s due to lengths.
@@ -152,8 +144,6 @@ impl LocalToken {
         message: &[u8],
         footer: Option<&[u8]>,
     ) -> Result<String, Error> {
-        use orion::hazardous::stream::xchacha20::XCHACHA_NONCESIZE;
-
         if message.is_empty() {
             return Err(Error::EmptyPayload);
         }
@@ -165,25 +155,18 @@ impl LocalToken {
     }
 
     /// Verify and decrypt a local token.
+    ///
+    /// If `footer.is_none()`, then it will be validated but not compared to a known value.
+    /// If `footer.is_some()`, then it will be validated AND compared to the known value.
     pub fn decrypt(
         secret_key: &SymmetricKey<V2>,
-        token: &str,
+        token: &UntrustedToken<V2>,
         footer: Option<&[u8]>,
-    ) -> Result<Vec<u8>, Error> {
-        use orion::hazardous::aead::xchacha20poly1305::*;
-        use orion::hazardous::mac::poly1305::POLY1305_OUTSIZE;
-        use orion::hazardous::stream::xchacha20::XCHACHA_NONCESIZE;
+    ) -> Result<TrustedToken, Error> {
+        validate_format_untrusted_token(Self::HEADER, token, footer)?;
 
-        if token.is_empty() {
-            return Err(Error::EmptyPayload);
-        }
-
-        let f = footer.unwrap_or(&[]);
-        let parts_split = validate_format_footer(Self::HEADER, token, f)?;
-        let nc = decode_b64(parts_split[2])?;
-        if nc.len() < (XCHACHA_NONCESIZE + POLY1305_OUTSIZE) {
-            return Err(Error::TokenFormat);
-        }
+        let f = token.untrusted_footer();
+        let nc = token.untrusted_message();
         let n = nc[..XCHACHA_NONCESIZE].as_ref();
         let c = nc[n.len()..].as_ref();
 
@@ -202,7 +185,7 @@ impl LocalToken {
             Some(pre_auth.as_ref()),
             &mut out,
         ) {
-            Ok(()) => Ok(out),
+            Ok(()) => TrustedToken::_new(Self::HEADER, &out, f, &[]),
             Err(orion::errors::UnknownCryptoError) => Err(Error::TokenValidation),
         }
     }
@@ -215,6 +198,7 @@ mod test_vectors {
     use hex;
 
     use super::*;
+    use core::convert::TryFrom;
     use std::fs::File;
     use std::io::BufReader;
 
@@ -229,11 +213,20 @@ mod test_vectors {
             SymmetricKey::<V2>::from(&hex::decode(test.key.as_ref().unwrap()).unwrap()).unwrap();
 
         let nonce = hex::decode(test.nonce.as_ref().unwrap()).unwrap();
-        let footer = test.footer.as_bytes();
+        let footer: Option<&[u8]> = if test.footer.as_bytes().is_empty() {
+            None
+        } else {
+            Some(test.footer.as_bytes())
+        };
 
         // payload is null when we expect failure
         if test.expect_fail {
-            assert!(LocalToken::decrypt(&sk, &test.token, Some(footer)).is_err());
+            match UntrustedToken::<V2>::try_from(&test.token) {
+                Ok(ut) => {
+                    assert!(LocalToken::decrypt(&sk, &ut, footer).is_err());
+                }
+                Err(_) => (),
+            }
 
             return;
         }
@@ -241,14 +234,18 @@ mod test_vectors {
         let message = test.payload.as_ref().unwrap().as_str().unwrap();
 
         let actual =
-            LocalToken::encrypt_with_derived_nonce(&sk, &nonce, message.as_bytes(), Some(footer))
+            LocalToken::encrypt_with_derived_nonce(&sk, &nonce, message.as_bytes(), footer)
                 .unwrap();
         assert_eq!(actual, test.token, "Failed {:?}", test.name);
 
-        let roundtrip = LocalToken::decrypt(&sk, &test.token, Some(footer)).unwrap();
-        assert_eq!(roundtrip, message.as_bytes(), "Failed {:?}", test.name);
+        let ut = UntrustedToken::<V2>::try_from(&test.token).unwrap();
+        let trusted = LocalToken::decrypt(&sk, &ut, footer).unwrap();
+        assert_eq!(trusted.payload(), message, "Failed {:?}", test.name);
+        assert_eq!(trusted.footer(), test.footer.as_bytes());
+        assert_eq!(trusted.header(), LocalToken::HEADER);
+        assert!(trusted.implicit_assert().is_empty());
 
-        let parsed_claims = Claims::from_bytes(&roundtrip).unwrap();
+        let parsed_claims = Claims::from_bytes(&trusted.payload().as_bytes()).unwrap();
         let test_vector_claims = serde_json::from_str::<Payload>(message).unwrap();
 
         assert_eq!(
@@ -273,24 +270,35 @@ mod test_vectors {
             &hex::decode(test.public_key.as_ref().unwrap()).unwrap(),
         )
         .unwrap();
-        let footer = test.footer.as_bytes();
+        let footer: Option<&[u8]> = if test.footer.as_bytes().is_empty() {
+            None
+        } else {
+            Some(test.footer.as_bytes())
+        };
 
         // payload is null when we expect failure
         if test.expect_fail {
-            assert!(PublicToken::verify(&pk, &test.token, Some(footer)).is_err());
+            match UntrustedToken::<V2>::try_from(&test.token) {
+                Ok(ut) => {
+                    assert!(PublicToken::verify(&pk, &ut, footer).is_err());
+                }
+                Err(_) => (),
+            }
 
             return;
         }
 
         let message = test.payload.as_ref().unwrap().as_str().unwrap();
 
-        let actual = PublicToken::sign(&sk, &pk, message.as_bytes(), Some(footer)).unwrap();
+        let actual = PublicToken::sign(&sk, &pk, message.as_bytes(), footer).unwrap();
         assert_eq!(actual, test.token, "Failed {:?}", test.name);
-        assert!(
-            PublicToken::verify(&pk, &test.token, Some(footer)).is_ok(),
-            "Failed {:?}",
-            test.name
-        );
+        let ut = UntrustedToken::<V2>::try_from(&test.token).unwrap();
+
+        let trusted = PublicToken::verify(&pk, &ut, footer).unwrap();
+        assert_eq!(trusted.payload(), message);
+        assert_eq!(trusted.footer(), test.footer.as_bytes());
+        assert_eq!(trusted.header(), PublicToken::HEADER);
+        assert!(trusted.implicit_assert().is_empty());
     }
 
     #[test]
@@ -301,11 +309,11 @@ mod test_vectors {
         let tests: TestFile = serde_json::from_reader(reader).unwrap();
 
         for t in tests.tests {
-            // v4.public
+            // v2.public
             if t.public_key.is_some() {
                 test_public(&t);
             }
-            // v4.local
+            // v2.local
             if t.nonce.is_some() {
                 test_local(&t);
             }
@@ -316,6 +324,7 @@ mod test_vectors {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::decode_b64;
     use crate::keys::{AsymmetricKeyPair, Generate};
     use crate::token::UntrustedToken;
     use core::convert::TryFrom;
@@ -341,7 +350,9 @@ mod tests {
         let kp = AsymmetricKeyPair::<V2>::generate().unwrap();
 
         let token = PublicToken::sign(&kp.secret, &kp.public, MESSAGE.as_bytes(), None).unwrap();
-        assert!(PublicToken::verify(&kp.public, &token, None).is_ok());
+
+        let ut = UntrustedToken::<V2>::try_from(&token).unwrap();
+        assert!(PublicToken::verify(&kp.public, &ut, None).is_ok());
     }
 
     #[test]
@@ -350,9 +361,13 @@ mod tests {
         let sk = SymmetricKey::<V2>::generate().unwrap();
         let token = LocalToken::encrypt(&sk, MESSAGE.as_bytes(), Some(FOOTER.as_bytes())).unwrap();
 
-        let untrusted_token = UntrustedToken::try_from(token.as_str()).unwrap();
-        let _ =
-            LocalToken::decrypt(&sk, &token, Some(untrusted_token.get_untrusted_footer())).unwrap();
+        let untrusted_token = UntrustedToken::<V2>::try_from(token.as_str()).unwrap();
+        let _ = LocalToken::decrypt(
+            &sk,
+            &untrusted_token,
+            Some(untrusted_token.untrusted_footer()),
+        )
+        .unwrap();
 
         // Public
         let kp = AsymmetricKeyPair::<V2>::generate().unwrap();
@@ -364,23 +379,20 @@ mod tests {
         )
         .unwrap();
 
-        let untrusted_token = UntrustedToken::try_from(token.as_str()).unwrap();
-        assert!(PublicToken::verify(
-            &kp.public,
-            &token,
-            Some(untrusted_token.get_untrusted_footer())
-        )
-        .is_ok());
+        let untrusted_token = UntrustedToken::<V2>::try_from(token.as_str()).unwrap();
+        assert!(PublicToken::verify(&kp.public, &untrusted_token, Some(FOOTER.as_bytes())).is_ok());
     }
 
     #[test]
     fn test_roundtrip_local() {
         let sk = SymmetricKey::<V2>::generate().unwrap();
+        let message = "token payload";
 
-        let token = LocalToken::encrypt(&sk, MESSAGE.as_bytes(), None).unwrap();
-        let payload = LocalToken::decrypt(&sk, &token, None).unwrap();
+        let token = LocalToken::encrypt(&sk, message.as_bytes(), None).unwrap();
+        let ut = UntrustedToken::<V2>::try_from(&token).unwrap();
+        let trusted_token = LocalToken::decrypt(&sk, &ut, None).unwrap();
 
-        assert_eq!(payload, MESSAGE.as_bytes());
+        assert_eq!(trusted_token.payload(), message);
     }
 
     #[test]
@@ -389,31 +401,55 @@ mod tests {
         let test_pk = AsymmetricPublicKey::<V2>::from(&TEST_PK_BYTES).unwrap();
 
         let token = PublicToken::sign(&test_sk, &test_pk, MESSAGE.as_bytes(), None).unwrap();
-        assert!(PublicToken::verify(&test_pk, &token, None).is_ok());
+        let ut = UntrustedToken::<V2>::try_from(&token).unwrap();
+
+        assert!(PublicToken::verify(&test_pk, &ut, None).is_ok());
     }
 
     #[test]
-    fn footer_none_some_empty_is_same() {
+    fn footer_logic() {
         let test_local_sk = SymmetricKey::<V2>::from(&TEST_SK_BYTES).unwrap();
         let test_sk = AsymmetricSecretKey::<V2>::from(&TEST_SK_BYTES).unwrap();
         let test_pk = AsymmetricPublicKey::<V2>::from(&TEST_PK_BYTES).unwrap();
         let message =
             b"{\"data\":\"this is a signed message\",\"exp\":\"2019-01-01T00:00:00+00:00\"}";
-        let footer = b"";
 
-        let actual_some = PublicToken::sign(&test_sk, &test_pk, message, Some(footer)).unwrap();
-        let actual_none = PublicToken::sign(&test_sk, &test_pk, message, None).unwrap();
-        assert_eq!(actual_some, actual_none);
+        // We create a token with Some(footer) and with None
+        let actual_some = UntrustedToken::<V2>::try_from(
+            &PublicToken::sign(&test_sk, &test_pk, message, Some(FOOTER.as_bytes())).unwrap(),
+        )
+        .unwrap();
+        let actual_none = UntrustedToken::<V2>::try_from(
+            &PublicToken::sign(&test_sk, &test_pk, message, None).unwrap(),
+        )
+        .unwrap();
 
-        assert!(PublicToken::verify(&test_pk, &actual_none, Some(footer)).is_ok());
+        // token = Some(footer) = validate and compare
+        // token = None(footer) = validate only
+
+        // We should be able to validate with None if created with Some() (excludes constant-time
+        // comparison with known value)
         assert!(PublicToken::verify(&test_pk, &actual_some, None).is_ok());
+        // We should be able to validate with Some() if created with Some()
+        assert!(PublicToken::verify(&test_pk, &actual_some, Some(FOOTER.as_bytes())).is_ok());
+        // We should NOT be able to validate with Some() if created with None
+        assert!(PublicToken::verify(&test_pk, &actual_none, Some(FOOTER.as_bytes())).is_err());
 
-        let actual_some = LocalToken::encrypt(&test_local_sk, message, Some(footer)).unwrap();
-        let actual_none = LocalToken::encrypt(&test_local_sk, message, None).unwrap();
+        let actual_some = UntrustedToken::<V2>::try_from(
+            &LocalToken::encrypt(&test_local_sk, message, Some(FOOTER.as_bytes())).unwrap(),
+        )
+        .unwrap();
+        let actual_none = UntrustedToken::<V2>::try_from(
+            &LocalToken::encrypt(&test_local_sk, message, None).unwrap(),
+        )
+        .unwrap();
+
         // They don't equal because the nonce is random. So we only check decryption.
-
-        assert!(LocalToken::decrypt(&test_local_sk, &actual_none, Some(footer)).is_ok());
         assert!(LocalToken::decrypt(&test_local_sk, &actual_some, None).is_ok());
+        assert!(LocalToken::decrypt(&test_local_sk, &actual_some, Some(FOOTER.as_bytes())).is_ok());
+        assert!(
+            LocalToken::decrypt(&test_local_sk, &actual_none, Some(FOOTER.as_bytes())).is_err()
+        );
     }
 
     #[test]
@@ -428,59 +464,8 @@ mod tests {
             Error::EmptyPayload
         );
         assert_eq!(
-            PublicToken::verify(&test_pk, "", None).unwrap_err(),
-            Error::EmptyPayload
-        );
-        assert_eq!(
             LocalToken::encrypt(&test_local_sk, b"", None).unwrap_err(),
             Error::EmptyPayload
-        );
-        assert_eq!(
-            LocalToken::decrypt(&test_local_sk, "", None).unwrap_err(),
-            Error::EmptyPayload
-        );
-    }
-
-    #[test]
-    fn err_on_modified_header() {
-        let test_pk = AsymmetricPublicKey::<V2>::from(&TEST_PK_BYTES).unwrap();
-        let test_local_sk = SymmetricKey::<V2>::from(&TEST_SK_BYTES).unwrap();
-
-        assert_eq!(
-            PublicToken::verify(
-                &test_pk,
-                &VALID_PUBLIC_TOKEN.replace("v2", "v1"),
-                Some(FOOTER.as_bytes())
-            )
-            .unwrap_err(),
-            Error::TokenFormat
-        );
-        assert_eq!(
-            LocalToken::decrypt(
-                &test_local_sk,
-                &VALID_LOCAL_TOKEN.replace("v2", "v1"),
-                Some(FOOTER.as_bytes())
-            )
-            .unwrap_err(),
-            Error::TokenFormat
-        );
-        assert_eq!(
-            PublicToken::verify(
-                &test_pk,
-                &VALID_PUBLIC_TOKEN.replace("v2", ""),
-                Some(FOOTER.as_bytes())
-            )
-            .unwrap_err(),
-            Error::TokenFormat
-        );
-        assert_eq!(
-            LocalToken::decrypt(
-                &test_local_sk,
-                &VALID_LOCAL_TOKEN.replace("v2", ""),
-                Some(FOOTER.as_bytes())
-            )
-            .unwrap_err(),
-            Error::TokenFormat
         );
     }
 
@@ -492,7 +477,8 @@ mod tests {
         assert_eq!(
             PublicToken::verify(
                 &test_pk,
-                &VALID_PUBLIC_TOKEN.replace("public", "local"),
+                &UntrustedToken::<V2>::try_from(&VALID_PUBLIC_TOKEN.replace("public", "local"))
+                    .unwrap(),
                 Some(FOOTER.as_bytes())
             )
             .unwrap_err(),
@@ -501,77 +487,11 @@ mod tests {
         assert_eq!(
             LocalToken::decrypt(
                 &test_local_sk,
-                &VALID_LOCAL_TOKEN.replace("local", "public"),
+                &UntrustedToken::<V2>::try_from(&VALID_LOCAL_TOKEN.replace("local", "public"))
+                    .unwrap(),
                 Some(FOOTER.as_bytes())
             )
             .unwrap_err(),
-            Error::TokenFormat
-        );
-        assert_eq!(
-            PublicToken::verify(
-                &test_pk,
-                &VALID_PUBLIC_TOKEN.replace("public", ""),
-                Some(FOOTER.as_bytes())
-            )
-            .unwrap_err(),
-            Error::TokenFormat
-        );
-        assert_eq!(
-            LocalToken::decrypt(
-                &test_local_sk,
-                &VALID_LOCAL_TOKEN.replace("local", ""),
-                Some(FOOTER.as_bytes())
-            )
-            .unwrap_err(),
-            Error::TokenFormat
-        );
-    }
-
-    #[test]
-    // NOTE: Missing but created with one
-    fn err_on_missing_payload() {
-        let test_pk = AsymmetricPublicKey::<V2>::from(&TEST_PK_BYTES).unwrap();
-        let test_local_sk = SymmetricKey::<V2>::from(&TEST_SK_BYTES).unwrap();
-
-        let mut split_public = VALID_PUBLIC_TOKEN.split('.').collect::<Vec<&str>>();
-        split_public[2] = "";
-        let invalid_public: String = split_public.iter().map(|x| *x).collect();
-
-        let mut split_local = VALID_LOCAL_TOKEN.split('.').collect::<Vec<&str>>();
-        split_local[2] = "";
-        let invalid_local: String = split_local.iter().map(|x| *x).collect();
-
-        assert_eq!(
-            PublicToken::verify(&test_pk, &invalid_public, Some(FOOTER.as_bytes())).unwrap_err(),
-            Error::TokenFormat
-        );
-        assert_eq!(
-            LocalToken::decrypt(&test_local_sk, &invalid_local, Some(FOOTER.as_bytes()))
-                .unwrap_err(),
-            Error::TokenFormat
-        );
-    }
-
-    #[test]
-    fn err_on_extra_after_footer() {
-        let test_pk = AsymmetricPublicKey::<V2>::from(&TEST_PK_BYTES).unwrap();
-        let test_local_sk = SymmetricKey::<V2>::from(&TEST_SK_BYTES).unwrap();
-
-        let mut split_public = VALID_PUBLIC_TOKEN.split('.').collect::<Vec<&str>>();
-        split_public.push(".shouldNotBeHere");
-        let invalid_public: String = split_public.iter().map(|x| *x).collect();
-
-        let mut split_local = VALID_LOCAL_TOKEN.split('.').collect::<Vec<&str>>();
-        split_local.push(".shouldNotBeHere");
-        let invalid_local: String = split_local.iter().map(|x| *x).collect();
-
-        assert_eq!(
-            PublicToken::verify(&test_pk, &invalid_public, Some(FOOTER.as_bytes())).unwrap_err(),
-            Error::TokenFormat
-        );
-        assert_eq!(
-            LocalToken::decrypt(&test_local_sk, &invalid_local, Some(FOOTER.as_bytes()))
-                .unwrap_err(),
             Error::TokenFormat
         );
     }
@@ -584,7 +504,7 @@ mod tests {
         assert_eq!(
             PublicToken::verify(
                 &test_pk,
-                &VALID_PUBLIC_TOKEN,
+                &UntrustedToken::<V2>::try_from(VALID_PUBLIC_TOKEN).unwrap(),
                 Some(&FOOTER.replace("kid", "mid").as_bytes())
             )
             .unwrap_err(),
@@ -593,7 +513,7 @@ mod tests {
         assert_eq!(
             LocalToken::decrypt(
                 &test_local_sk,
-                &VALID_LOCAL_TOKEN,
+                &UntrustedToken::<V2>::try_from(VALID_LOCAL_TOKEN).unwrap(),
                 Some(&FOOTER.replace("kid", "mid").as_bytes())
             )
             .unwrap_err(),
@@ -607,11 +527,21 @@ mod tests {
         let test_local_sk = SymmetricKey::<V2>::from(&TEST_SK_BYTES).unwrap();
 
         assert_eq!(
-            PublicToken::verify(&test_pk, &VALID_PUBLIC_TOKEN, Some(b"")).unwrap_err(),
+            PublicToken::verify(
+                &test_pk,
+                &UntrustedToken::<V2>::try_from(VALID_PUBLIC_TOKEN).unwrap(),
+                Some(b"")
+            )
+            .unwrap_err(),
             Error::TokenValidation
         );
         assert_eq!(
-            LocalToken::decrypt(&test_local_sk, &VALID_LOCAL_TOKEN, Some(b"")).unwrap_err(),
+            LocalToken::decrypt(
+                &test_local_sk,
+                &UntrustedToken::<V2>::try_from(VALID_LOCAL_TOKEN).unwrap(),
+                Some(b"")
+            )
+            .unwrap_err(),
             Error::TokenValidation
         );
     }
@@ -632,12 +562,21 @@ mod tests {
             format!("{}.{}.{}", split_local[0], split_local[1], split_local[2]);
 
         assert_eq!(
-            PublicToken::verify(&test_pk, &invalid_public, Some(FOOTER.as_bytes())).unwrap_err(),
+            PublicToken::verify(
+                &test_pk,
+                &UntrustedToken::<V2>::try_from(&invalid_public).unwrap(),
+                Some(FOOTER.as_bytes())
+            )
+            .unwrap_err(),
             Error::TokenValidation
         );
         assert_eq!(
-            LocalToken::decrypt(&test_local_sk, &invalid_local, Some(FOOTER.as_bytes()))
-                .unwrap_err(),
+            LocalToken::decrypt(
+                &test_local_sk,
+                &UntrustedToken::<V2>::try_from(&invalid_local).unwrap(),
+                Some(FOOTER.as_bytes())
+            )
+            .unwrap_err(),
             Error::TokenValidation
         );
     }
@@ -657,7 +596,12 @@ mod tests {
         );
 
         assert_eq!(
-            PublicToken::verify(&test_pk, &invalid_public, Some(FOOTER.as_bytes())).unwrap_err(),
+            PublicToken::verify(
+                &test_pk,
+                &UntrustedToken::<V2>::try_from(&invalid_public).unwrap(),
+                Some(FOOTER.as_bytes())
+            )
+            .unwrap_err(),
             Error::TokenValidation
         );
     }
@@ -678,8 +622,12 @@ mod tests {
         );
 
         assert_eq!(
-            LocalToken::decrypt(&test_local_sk, &invalid_local, Some(FOOTER.as_bytes()))
-                .unwrap_err(),
+            LocalToken::decrypt(
+                &test_local_sk,
+                &UntrustedToken::<V2>::try_from(&invalid_local).unwrap(),
+                Some(FOOTER.as_bytes())
+            )
+            .unwrap_err(),
             Error::TokenValidation
         );
     }
@@ -700,8 +648,12 @@ mod tests {
         );
 
         assert_eq!(
-            LocalToken::decrypt(&test_local_sk, &invalid_local, Some(FOOTER.as_bytes()))
-                .unwrap_err(),
+            LocalToken::decrypt(
+                &test_local_sk,
+                &UntrustedToken::<V2>::try_from(&invalid_local).unwrap(),
+                Some(FOOTER.as_bytes())
+            )
+            .unwrap_err(),
             Error::TokenValidation
         );
     }
@@ -722,30 +674,12 @@ mod tests {
         );
 
         assert_eq!(
-            LocalToken::decrypt(&test_local_sk, &invalid_local, Some(FOOTER.as_bytes()))
-                .unwrap_err(),
-            Error::TokenValidation
-        );
-    }
-
-    #[test]
-    fn err_on_invalid_base64() {
-        let test_local_sk = SymmetricKey::<V2>::from(&TEST_SK_BYTES).unwrap();
-
-        let mut split_local = VALID_LOCAL_TOKEN.split('.').collect::<Vec<&str>>();
-        let mut bad_nonce = Vec::from(decode_b64(split_local[2]).unwrap());
-        let nlen = bad_nonce.len();
-        bad_nonce.copy_within((nlen - 24)..nlen, 0);
-        let tmp = encode_b64(bad_nonce).unwrap();
-        split_local[2] = &tmp;
-        let invalid_local: String = format!(
-            "{}.{}.{}.{}",
-            split_local[0], split_local[1], split_local[2], split_local[3]
-        );
-
-        assert_eq!(
-            LocalToken::decrypt(&test_local_sk, &invalid_local, Some(FOOTER.as_bytes()))
-                .unwrap_err(),
+            LocalToken::decrypt(
+                &test_local_sk,
+                &UntrustedToken::<V2>::try_from(&invalid_local).unwrap(),
+                Some(FOOTER.as_bytes())
+            )
+            .unwrap_err(),
             Error::TokenValidation
         );
     }
@@ -755,7 +689,12 @@ mod tests {
         let bad_pk = AsymmetricPublicKey::<V2>::from(&[0u8; 32]).unwrap();
 
         assert_eq!(
-            PublicToken::verify(&bad_pk, VALID_PUBLIC_TOKEN, Some(FOOTER.as_bytes())).unwrap_err(),
+            PublicToken::verify(
+                &bad_pk,
+                &UntrustedToken::<V2>::try_from(VALID_PUBLIC_TOKEN).unwrap(),
+                Some(FOOTER.as_bytes())
+            )
+            .unwrap_err(),
             Error::TokenValidation
         );
     }
@@ -765,8 +704,12 @@ mod tests {
         let bad_local_sk = SymmetricKey::<V2>::from(&[0u8; 32]).unwrap();
 
         assert_eq!(
-            LocalToken::decrypt(&bad_local_sk, VALID_LOCAL_TOKEN, Some(FOOTER.as_bytes()))
-                .unwrap_err(),
+            LocalToken::decrypt(
+                &bad_local_sk,
+                &UntrustedToken::<V2>::try_from(VALID_LOCAL_TOKEN).unwrap(),
+                Some(FOOTER.as_bytes())
+            )
+            .unwrap_err(),
             Error::TokenValidation
         );
     }

--- a/src/version3.rs
+++ b/src/version3.rs
@@ -14,7 +14,7 @@
 //! [AsymmetricPublicKey<V3>]: crate::keys::AsymmetricPublicKey
 //! [UncompressedPublicKey]: crate::version3::UncompressedPublicKey
 
-use crate::common::{encode_b64, validate_format_untrusted_token};
+use crate::common::{encode_b64, validate_footer_untrusted_token};
 use crate::errors::Error;
 use crate::keys::{AsymmetricPublicKey, AsymmetricSecretKey};
 use crate::token::{Public, TrustedToken, UntrustedToken};
@@ -268,7 +268,7 @@ impl PublicToken {
         footer: Option<&[u8]>,
         implicit_assert: Option<&[u8]>,
     ) -> Result<TrustedToken, Error> {
-        validate_format_untrusted_token(Self::HEADER, token, footer)?;
+        validate_footer_untrusted_token(token, footer)?;
 
         let f = token.untrusted_footer();
         let i = implicit_assert.unwrap_or(&[]);

--- a/src/version3.rs
+++ b/src/version3.rs
@@ -549,6 +549,7 @@ mod test_wycheproof_point_compression {
 mod tests {
     use super::*;
     use crate::keys::{AsymmetricKeyPair, Generate};
+    use crate::token::UntrustedToken;
 
     // 3-S-2 values
     const TEST_SK_BYTES: [u8; 48] = [
@@ -574,6 +575,29 @@ mod tests {
         let token =
             PublicToken::sign(&kp.secret, &kp.public, MESSAGE.as_bytes(), None, None).unwrap();
         assert!(PublicToken::verify(&kp.public, &token, None, None).is_ok());
+    }
+
+    #[test]
+    fn test_untrusted_token_usage() {
+        // Public
+        let kp = AsymmetricKeyPair::<V3>::generate().unwrap();
+        let token = PublicToken::sign(
+            &kp.secret,
+            &kp.public,
+            MESSAGE.as_bytes(),
+            Some(FOOTER.as_bytes()),
+            None,
+        )
+        .unwrap();
+
+        let untrusted_token = UntrustedToken::try_from(token.as_str()).unwrap();
+        assert!(PublicToken::verify(
+            &kp.public,
+            &token,
+            Some(untrusted_token.get_untrusted_footer()),
+            None
+        )
+        .is_ok());
     }
 
     #[test]

--- a/src/version4.rs
+++ b/src/version4.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(docsrs, doc(cfg(feature = "v4")))]
 
-use crate::common::{encode_b64, validate_format_untrusted_token};
+use crate::common::{encode_b64, validate_footer_untrusted_token};
 use crate::errors::Error;
 use crate::keys::{AsymmetricPublicKey, AsymmetricSecretKey, SymmetricKey};
 use crate::token::{Local, Public, TrustedToken, UntrustedToken};
@@ -68,7 +68,7 @@ impl PublicToken {
         footer: Option<&[u8]>,
         implicit_assert: Option<&[u8]>,
     ) -> Result<TrustedToken, Error> {
-        validate_format_untrusted_token(Self::HEADER, token, footer)?;
+        validate_footer_untrusted_token(token, footer)?;
 
         let f = token.untrusted_footer();
         let i = implicit_assert.unwrap_or(&[]);
@@ -207,7 +207,7 @@ impl LocalToken {
         footer: Option<&[u8]>,
         implicit_assert: Option<&[u8]>,
     ) -> Result<TrustedToken, Error> {
-        validate_format_untrusted_token(Self::HEADER, token, footer)?;
+        validate_footer_untrusted_token(token, footer)?;
 
         let f = token.untrusted_footer();
         let i = implicit_assert.unwrap_or(&[]);

--- a/src/version4.rs
+++ b/src/version4.rs
@@ -382,7 +382,7 @@ mod tests {
     use super::*;
     use crate::keys::{AsymmetricKeyPair, Generate, SymmetricKey};
     use crate::token::UntrustedToken;
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     // In version 2 tests, the SK used for public tokens is valid for the local as well.
     // Not the case with version 4.


### PR DESCRIPTION
See #47

This adds an `UntrustedToken` type which can be used to parse things like the footer, from an unverified token, in order to verify it. It also adds `TrustedToken`. Both types are part of both low-level and high-level APIs now. The latter let's you easily access individual parts of authenticated and validated tokens with claims.

@Eh2406 if you have a minute, could you check the API of `UntrustedToken` and see if this fulfills your requirements?




Remaining things:
- [x] Include `TrustedToken` in this PR? `TrustedToken` that can only be created internally and returned by `verify()`/`decrypt()` (current high-level API can parse claims from this or switch to returning `TrustedToken` as well) (it is included)
- [x] `verify()` should at least return the decoded base64 messages, after verification instead of `Result<()>` if `TrustedToken` isn't implemented (`TrustedToken` is included)
- [x] Update changelog 
- [x] Make `UntrustedToken` part of the overall API? Then `verify()`/`decrypt()` could take these instead of `String` so that the validation logic of the token format/base64 decoding isn't performed twice. Then it makes much more sense to return `TrustedToken` as well. Then the footer in the `UntrustedToken` will be verified if `footer = Some(&[data])` but and compared constant time. If `footer = None`, then the footer will be validated if present, but not compared constant-time.