### PR TITLE
Add `Footer` type for JSON-encoded footers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ __Changelog:__
 - Add new types `token::UntrustedToken` and `token::TrustedToken` which are now used by `verify()`/`decrypt()` operations. 
 These allow extracting parts of tokens before and after verification ([#47](https://github.com/brycx/pasetors/issues/47)) 
 - Version structs previously available in `keys::` have been moved to a new `version::` module
+- Add `Footer` type that makes it easier to create JSON-encoded footers ([#52](https://github.com/brycx/pasetors/pull/52))
 
 ### 0.4.2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pasetors"
-version = "0.5.0-alpha.4" # Update html_root_url in lib.rs along with this.
+version = "0.5.0-alpha.5" # Update html_root_url in lib.rs along with this.
 authors = ["brycx <brycx@protonmail.com>"]
 edition = "2018"
 description = "PASETO: Platform-Agnostic Security Tokens (in Rust)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,9 +80,13 @@ optional = true
 version = "0.2.1"
 optional = true
 
+[dependencies.regex]
+version = "1.5.5"
+optional = true
+
 [features]
 default = [ "std", "v4", "paserk" ]
-std = [ "serde_json", "time" ]
+std = [ "serde_json", "time", "regex" ]
 v2 = [ "orion", "ed25519-compact" ]
 v3 = [ "num-bigint", "num-traits", "ring", "pkcs8", "sec1" ]
 v4 = [ "orion", "ed25519-compact" ]

--- a/fuzz/fuzz_targets/fuzz_types.rs
+++ b/fuzz/fuzz_targets/fuzz_types.rs
@@ -6,10 +6,16 @@ use libfuzzer_sys::fuzz_target;
 use pasetors::claims::*;
 use pasetors::token::UntrustedToken;
 use pasetors::{Local, Public, V2, V3, V4};
+use pasetors::footer::Footer;
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(parsed_claims) = Claims::from_bytes(data) {
         assert!(parsed_claims.to_string().is_ok());
+    }
+
+    let mut footer = Footer::new();
+    if let Ok(()) = footer.parse_bytes(data) {
+        assert!(footer.to_string().is_ok());
     }
 
     let message: String = String::from_utf8_lossy(data).into();

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -35,6 +35,8 @@ pub enum Error {
     KeyGeneration,
     /// The payload was not valid UTF-8.
     PayloadInvalidUtf8,
+    /// Error during parsing of a `Footer`.
+    FooterParsing,
 }
 
 #[cfg(feature = "std")]

--- a/src/footer.rs
+++ b/src/footer.rs
@@ -1,0 +1,190 @@
+use crate::errors::Error;
+use crate::paserk::{FormatAsPaserk, Id};
+use regex::Regex;
+use serde_json::Value;
+use std::collections::HashMap;
+
+#[derive(Debug, PartialEq, Clone)]
+/// A footer with optional claims that are JSON-encoded.
+pub struct Footer {
+    list_of: HashMap<String, Value>,
+    max_keys: usize,
+    max_len: usize,
+}
+
+impl Default for Footer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Footer {
+    /// Keys for registered claims in the footer, that are reserved for usage by PASETO in top-level.
+    pub const REGISTERED_CLAIMS: [&'static str; 2] = ["kid", "wpk"];
+
+    /// All PASERK types that are (implemented in this library) unsafe in the footer.
+    pub const DISALLOWED_FOOTER: [&'static str; 8] = [
+        "k2.local.",
+        "k4.local.",
+        "k2.secret.",
+        "k3.secret.",
+        "k4.secret.",
+        "k2.public.",
+        "k3.public.",
+        "k4.public.",
+    ];
+
+    /// See [PASETO docs] for the reason behind this limit.
+    ///
+    /// Maximum number of named keys within an object.
+    ///
+    /// [PASETO docs]: https://github.com/paseto-standard/paseto-spec/blob/master/docs/02-Implementation-Guide/01-Payload-Processing.md#enforcing-maximum-depth-without-parsing-the-json-string
+    pub const DEFAULT_MAX_KEYS: usize = 512;
+
+    /// See [PASETO docs] for the reason behind this limit.
+    ///
+    /// Maximum length of the JSON-encoded string.
+    ///
+    /// [PASETO docs]: https://github.com/paseto-standard/paseto-spec/blob/master/docs/02-Implementation-Guide/01-Payload-Processing.md#enforcing-maximum-depth-without-parsing-the-json-string
+    pub const DEFAULT_MAX_LEN: usize = 8192;
+
+    /// See [PASETO docs] for the reason behind this limit.
+    ///
+    /// This value has been set by `serde_json` and cannot be changed.
+    ///
+    /// [PASETO docs]: https://github.com/paseto-standard/paseto-spec/blob/master/docs/02-Implementation-Guide/01-Payload-Processing.md#enforcing-maximum-depth-without-parsing-the-json-string
+    pub const MAX_RECURSION_DEPTH: usize = 128;
+
+    /// Create a new `Footer` instance.
+    pub fn new() -> Self {
+        Self {
+            list_of: HashMap::new(),
+            max_keys: Self::DEFAULT_MAX_KEYS,
+            max_len: Self::DEFAULT_MAX_LEN,
+        }
+    }
+
+    /// Change the default (512) amount of maximum number of named keys within an object.
+    ///
+    /// __NOTE__: There should be no need to change this if you don't know this is a specific problem for you.
+    pub fn max_keys(&mut self, max_keys: usize) {
+        self.max_keys = max_keys;
+    }
+
+    /// Change the default (8192) amount of maximum number of named keys within an object.
+    ///
+    /// __NOTE__: There should be no need to change this if you don't know this is a specific problem for you.
+    pub fn max_len(&mut self, max_len: usize) {
+        self.max_len = max_len;
+    }
+
+    /// Add additional claims. If `claim` already exists, it is replaced with the new.
+    ///
+    /// Errors:
+    /// - `claim` is a reserved claim (see [`Self::REGISTERED_CLAIMS`])
+    /// - `value` is any of (starts with) the disallowed PASERK types (see [`Self::DISALLOWED_FOOTER`]).
+    pub fn add_additional(&mut self, claim: &str, value: &str) -> Result<(), Error> {
+        for unsafe_value in Self::DISALLOWED_FOOTER {
+            if value.starts_with(unsafe_value) {
+                return Err(Error::InvalidClaim);
+            }
+        }
+
+        if !Self::REGISTERED_CLAIMS.contains(&claim) {
+            self.list_of.insert(claim.into(), value.into());
+            Ok(())
+        } else {
+            Err(Error::InvalidClaim)
+        }
+    }
+
+    /// Checks whether a specific claim has been added to the list.
+    ///
+    /// E.g `contains_claim("kid") == true` if `kid` has been added before.
+    pub fn contains_claim(&self, claim: &str) -> bool {
+        self.list_of.contains_key(claim)
+    }
+
+    /// Return Some(claim value) if claims list contains the `claim`.
+    /// None otherwise.
+    pub fn get_claim(&self, claim: &str) -> Option<&Value> {
+        self.list_of.get(claim)
+    }
+
+    /// Set the `kid` claim. If it already exists, replace it with the new.
+    pub fn key_id(&mut self, id: &Id) {
+        let mut paserk_kid = String::new();
+        id.fmt(&mut paserk_kid).unwrap();
+
+        self.list_of.insert("kid".into(), paserk_kid.into());
+    }
+
+    /// Attempt to create `Footer` from a sequence of bytes.
+    ///
+    /// Errors:
+    /// - `bytes` contains non-UTF-8 sequences
+    /// - `bytes` does not decode as valid JSON
+    /// - `bytes` top-most JSON object does not decode to a map
+    /// - if any registered claims exist and they are not a `String`
+    /// - Parsing JSON maps and arrays that are more than 128 layers deep
+    /// - Maximum number of named keys is exceeded
+    /// - Maximum JSON-encoded string length is exceeded
+    pub fn parse_bytes(&mut self, bytes: &[u8]) -> Result<(), Error> {
+        let input = bytes.to_vec();
+
+        self.parse_string(&String::from_utf8(input).map_err(|_| Error::FooterParsing)?)
+    }
+
+    /// Attempt to parse a `Footer` from a string.
+    ///
+    /// Errors:
+    /// - `string` does not decode as valid JSON
+    /// - `string` top-most JSON object does not decode to a map
+    /// - if any registered claims exist and they are not a `String`
+    /// - Parsing JSON maps and arrays that are more than 128 layers deep
+    /// - Maximum number of named keys is exceeded
+    /// - Maximum JSON-encoded string length is exceeded
+    pub fn parse_string(&mut self, string: &str) -> Result<(), Error> {
+        if string.len() > self.max_len {
+            return Err(Error::FooterParsing);
+        }
+        if Regex::new(r#"[^\\]":"#).unwrap().find_iter(string).count() > self.max_keys {
+            return Err(Error::FooterParsing);
+        }
+
+        self.list_of = serde_json::from_str(string).map_err(|_| Error::FooterParsing)?;
+
+        Ok(())
+    }
+
+    /// Return the JSON serialized representation of `Self`.
+    ///
+    /// Errors:
+    /// - `self` cannot be serialized as JSON
+    pub fn to_string(&self) -> Result<String, Error> {
+        match serde_json::to_string(&self.list_of) {
+            Ok(ret) => Ok(ret),
+            Err(_) => Err(Error::FooterParsing),
+        }
+    }
+}
+
+#[test]
+fn test_count_keys() {
+    // https://www.rustescaper.com/
+    let string = r#""name": "3-S-2",
+      "expect-fail": false,
+      "public-key": "02fbcb7c69ee1c60579be7a334134878d9c5c5bf35d552dab63c0140397ed14cef637d7720925c44699ea30e72874c72fb",
+      "secret-key": "20347609607477aca8fbfbc5e6218455f3199669792ef8b466faa87bdc67798144c848dd03661eed5ac62461340cea96",
+      "secret-key-pem": "-----BEGIN EC PRIVATE KEY-----nMIGkAgEBBDAgNHYJYHR3rKj7+8XmIYRV8xmWaXku+LRm+qh73Gd5gUTISN0DZh7tnWsYkYTQM6pagBwYFK4EEACKhZANiAAT7y3xp7hxgV5vnozQTSHjZxcW/NdVS2rY8nAUA5ftFM72N9dyCSXERpnqMOcodMcvt8kgcrB8KcKee0HU23E79/s4CvEs8hBfnjnSUd/gcAm08EjSIz06iWjrNy4NakxR3I=n-----END EC PRIVATE KEY-----",
+      "public-key-pem": "-----BEGIN PUBLIC KEY-----nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+8t8ae4cYFeb56M0E0h42cXFvzXVUtq2nPAFAOX7RTO9jfXcgklxEaZ6jDnKHTHL7fJIHKwfCnCnntB1NtxO/f7OArxLPIQX5n40lHf4HAJtPBI0iM9Oolo6zcuDWpMUdyn-----END PUBLIC KEY-----",
+      "token": "v3.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9ZWrbGZ6L0MDK72skosUaS0Dz7wJ_2bMcM6tOxFuCasO9GhwHrvvchqgXQNLQQyWzGC2wkr-VKII71AvkLpC8tJOrzJV1cap9NRwoFzbcXjzMZyxQ0wkshxZxx8ImmNWP.eyJraWQiOiJkWWtJU3lseFFlZWNFY0hFTGZ6Rjg4VVpyd2JMb2xOaUNkcHpVSEd3OVVxbiJ9",
+      "payload": "{"data":"this is a signed message","exp":"2022-01-01T00:00:00+00:00"}",
+      "footer": "{"kid":"dYkISylxQeecEcHELfzF88UZrwbLolNiCdpzUHGw9Uqn"}",
+      "implicit-assertion": """#;
+
+    assert_eq!(
+        Regex::new(r#"[^\\]":"#).unwrap().find_iter(string).count(),
+        13
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,10 @@ mod common;
 /// Claims for tokens and validation thereof.
 pub mod claims;
 
+#[cfg(feature = "std")]
+/// Footer for tokens and validation thereof.
+pub mod footer;
+
 /// Keys used for PASETO tokens.
 pub mod keys;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! // Generate the keys and sign the claims.
 //! let kp = AsymmetricKeyPair::<V4>::generate()?;
-//! let pub_token = public::sign(&kp.secret, &kp.public, &claims, Some(b"footer"), Some(b"implicit assertion"))?;
+//! let pub_token = public::sign(&kp.secret, &kp.public, &claims, None, Some(b"implicit assertion"))?;
 //!
 //! // Decide how we want to validate the claims after verifying the token itself.
 //! // The default verifies the `nbf`, `iat` and `exp` claims. `nbf` and `iat` are always
@@ -34,7 +34,7 @@
 //! // manually.
 //! let validation_rules = ClaimsValidationRules::new();
 //! let untrusted_token = UntrustedToken::<Public, V4>::try_from(&pub_token)?;
-//! let trusted_token = public::verify(&kp.public, &untrusted_token, &validation_rules, Some(b"footer"), Some(b"implicit assertion"))?;
+//! let trusted_token = public::verify(&kp.public, &untrusted_token, &validation_rules, None, Some(b"implicit assertion"))?;
 //! assert_eq!(&claims, trusted_token.payload_claims().unwrap());
 //!
 //! let claims = trusted_token.payload_claims().unwrap();
@@ -60,7 +60,7 @@
 //!
 //! // Generate the key and encrypt the claims.
 //! let sk = SymmetricKey::<V4>::generate()?;
-//! let token = local::encrypt(&sk, &claims, Some(b"footer"), Some(b"implicit assertion"))?;
+//! let token = local::encrypt(&sk, &claims, None, Some(b"implicit assertion"))?;
 //!
 //! // Decide how we want to validate the claims after verifying the token itself.
 //! // The default verifies the `nbf`, `iat` and `exp` claims. `nbf` and `iat` are always
@@ -69,7 +69,7 @@
 //! // manually.
 //! let validation_rules = ClaimsValidationRules::new();
 //! let untrusted_token = UntrustedToken::<Local, V4>::try_from(&token)?;
-//! let trusted_token = local::decrypt(&sk, &untrusted_token, &validation_rules, Some(b"footer"), Some(b"implicit assertion"))?;
+//! let trusted_token = local::decrypt(&sk, &untrusted_token, &validation_rules, None, Some(b"implicit assertion"))?;
 //! assert_eq!(&claims, trusted_token.payload_claims().unwrap());
 //!
 //! let claims = trusted_token.payload_claims().unwrap();
@@ -117,6 +117,42 @@
 //! // Now claims can be validated as non-expiring when we define the validation rule as:
 //! let mut validation_rules = ClaimsValidationRules::new();
 //! validation_rules.allow_non_expiring();
+//!
+//! # Ok::<(), pasetors::errors::Error>(())
+//! ```
+
+//! ## Footer with registered and custom claims
+//! ```rust
+//! use pasetors::paserk::{FormatAsPaserk, Id};
+//! use pasetors::claims::{Claims, ClaimsValidationRules};
+//! use pasetors::footer::Footer;
+//! use pasetors::keys::{Generate, AsymmetricKeyPair};
+//! use pasetors::{public, Public, V4};
+//! use pasetors::token::UntrustedToken;
+//! use core::convert::TryFrom;
+//!
+//! // Generate the key used to later sign a token.
+//! let kp = AsymmetricKeyPair::<V4>::generate()?;
+//! // Serialize the public key to PASERK "pid".
+//! let mut pid = Id::from(&kp.public);
+//! // Add the "pid" to the "kid" claim of a footer.
+//! let mut footer = Footer::new();
+//! footer.key_id(&pid);
+//! footer.add_additional("custom_footer_claim", "custom_value")?;
+//!
+//! let mut claims = Claims::new()?;
+//! let pub_token = public::sign(&kp.secret, &kp.public, &claims, Some(&footer), Some(b"implicit assertion"))?;
+//!
+//! // If we receive a token that needs to be verified, we can still try to parse a Footer from it
+//! // as long one was used during creation, if we don't know it beforehand.
+//! let validation_rules = ClaimsValidationRules::new();
+//! let untrusted_token = UntrustedToken::<Public, V4>::try_from(&pub_token)?;
+//! let trusted_token = public::verify(&kp.public, &untrusted_token, &validation_rules, None, Some(b"implicit assertion"))?;
+//! let trusted_footer = Footer::try_from(&trusted_token)?;
+//!
+//! let mut kid = String::new();
+//! pid.fmt(&mut kid).unwrap();
+//! assert_eq!(trusted_footer.get_claim("kid").unwrap().as_str().unwrap(), kid);
 //!
 //! # Ok::<(), pasetors::errors::Error>(())
 //! ```
@@ -205,6 +241,7 @@ pub mod public {
     use super::*;
     use crate::claims::{Claims, ClaimsValidationRules};
     use crate::errors::Error;
+    use crate::footer::Footer;
     use crate::keys::{AsymmetricPublicKey, AsymmetricSecretKey};
     use crate::token::{TrustedToken, UntrustedToken};
 
@@ -213,16 +250,25 @@ pub mod public {
         secret_key: &AsymmetricSecretKey<V4>,
         public_key: &AsymmetricPublicKey<V4>,
         message: &Claims,
-        footer: Option<&[u8]>,
+        footer: Option<&Footer>,
         implicit_assert: Option<&[u8]>,
     ) -> Result<String, Error> {
-        crate::version4::PublicToken::sign(
-            secret_key,
-            public_key,
-            message.to_string()?.as_bytes(),
-            footer,
-            implicit_assert,
-        )
+        match footer {
+            Some(f) => crate::version4::PublicToken::sign(
+                secret_key,
+                public_key,
+                message.to_string()?.as_bytes(),
+                Some(f.to_string()?.as_bytes()),
+                implicit_assert,
+            ),
+            None => crate::version4::PublicToken::sign(
+                secret_key,
+                public_key,
+                message.to_string()?.as_bytes(),
+                None,
+                implicit_assert,
+            ),
+        }
     }
 
     /// Verify a public token using the latest PASETO version (v4). If verification passes,
@@ -231,11 +277,18 @@ pub mod public {
         public_key: &AsymmetricPublicKey<V4>,
         token: &UntrustedToken<Public, V4>,
         validation_rules: &ClaimsValidationRules,
-        footer: Option<&[u8]>,
+        footer: Option<&Footer>,
         implicit_assert: Option<&[u8]>,
     ) -> Result<TrustedToken, Error> {
-        let mut trusted_token =
-            crate::version4::PublicToken::verify(public_key, token, footer, implicit_assert)?;
+        let mut trusted_token = match footer {
+            Some(f) => crate::version4::PublicToken::verify(
+                public_key,
+                token,
+                Some(f.to_string()?.as_bytes()),
+                implicit_assert,
+            )?,
+            None => crate::version4::PublicToken::verify(public_key, token, None, implicit_assert)?,
+        };
 
         let claims = Claims::from_string(trusted_token.payload())?;
         validation_rules.validate_claims(&claims)?;
@@ -252,6 +305,7 @@ pub mod local {
     use super::*;
     use crate::claims::{Claims, ClaimsValidationRules};
     use crate::errors::Error;
+    use crate::footer::Footer;
     use crate::keys::SymmetricKey;
     use crate::token::{TrustedToken, UntrustedToken};
 
@@ -259,15 +313,23 @@ pub mod local {
     pub fn encrypt(
         secret_key: &SymmetricKey<V4>,
         message: &Claims,
-        footer: Option<&[u8]>,
+        footer: Option<&Footer>,
         implicit_assert: Option<&[u8]>,
     ) -> Result<String, Error> {
-        crate::version4::LocalToken::encrypt(
-            secret_key,
-            message.to_string()?.as_bytes(),
-            footer,
-            implicit_assert,
-        )
+        match footer {
+            Some(f) => crate::version4::LocalToken::encrypt(
+                secret_key,
+                message.to_string()?.as_bytes(),
+                Some(f.to_string()?.as_bytes()),
+                implicit_assert,
+            ),
+            None => crate::version4::LocalToken::encrypt(
+                secret_key,
+                message.to_string()?.as_bytes(),
+                None,
+                implicit_assert,
+            ),
+        }
     }
 
     /// Verify a local token using the latest PASETO version (v4). If verification passes,
@@ -276,11 +338,18 @@ pub mod local {
         secret_key: &SymmetricKey<V4>,
         token: &UntrustedToken<Local, V4>,
         validation_rules: &ClaimsValidationRules,
-        footer: Option<&[u8]>,
+        footer: Option<&Footer>,
         implicit_assert: Option<&[u8]>,
     ) -> Result<TrustedToken, Error> {
-        let mut trusted_token =
-            crate::version4::LocalToken::decrypt(secret_key, token, footer, implicit_assert)?;
+        let mut trusted_token = match footer {
+            Some(f) => crate::version4::LocalToken::decrypt(
+                secret_key,
+                token,
+                Some(f.to_string()?.as_bytes()),
+                implicit_assert,
+            )?,
+            None => crate::version4::LocalToken::decrypt(secret_key, token, None, implicit_assert)?,
+        };
 
         let claims = Claims::from_string(trusted_token.payload())?;
         validation_rules.validate_claims(&claims)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@ mod common;
 pub mod claims;
 
 #[cfg(feature = "std")]
-/// Footer for tokens and validation thereof.
+/// Footer for tokens.
 pub mod footer;
 
 /// Keys used for PASETO tokens.


### PR DESCRIPTION
TODO:

- [x] Expand tests. Especially those regarding `max_len`/`max_keys` as well
- [x] Check error types of each method are okay. Some may still be leftover from `Claims` which `Footer` is a copy of
- [x] Add example of using this in the high-level API/docs
- [x] High-level API should take a `Footer` instance instead of `Option<&[u8]>`, but the lower-level APIs should still take the byte-slice. If lower-level API is used with `Footer`, the user can `to_string().as_bytes()`
- [x] Update changelog
- [x] Add fuzzer target (this can be combined with a fuzzer for `Claims`)