### PR TITLE
Implement `Debug` + `Clone` + `PartialEq` where missing

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -55,6 +55,13 @@ impl<V> Debug for SymmetricKey<V> {
     }
 }
 
+impl<V: Version> PartialEq<SymmetricKey<V>> for SymmetricKey<V> {
+    fn eq(&self, other: &SymmetricKey<V>) -> bool {
+        use subtle::ConstantTimeEq;
+        self.as_bytes().ct_eq(other.as_bytes()).into()
+    }
+}
+
 /// An asymmetric secret key used for `.public` tokens, given a version `V`.
 pub struct AsymmetricSecretKey<V> {
     pub(crate) bytes: Vec<u8>,
@@ -91,6 +98,13 @@ impl<V> Debug for AsymmetricSecretKey<V> {
     }
 }
 
+impl<V: Version> PartialEq<AsymmetricSecretKey<V>> for AsymmetricSecretKey<V> {
+    fn eq(&self, other: &AsymmetricSecretKey<V>) -> bool {
+        use subtle::ConstantTimeEq;
+        self.as_bytes().ct_eq(other.as_bytes()).into()
+    }
+}
+
 #[derive(Debug, Clone)]
 /// An asymmetric public key used for `.public` tokens, given a version `V`.
 pub struct AsymmetricPublicKey<V> {
@@ -112,6 +126,13 @@ impl<V: Version> AsymmetricPublicKey<V> {
     /// Return this as a byte-slice.
     pub fn as_bytes(&self) -> &[u8] {
         self.bytes.as_slice()
+    }
+}
+
+impl<V: Version> PartialEq<AsymmetricPublicKey<V>> for AsymmetricPublicKey<V> {
+    fn eq(&self, other: &AsymmetricPublicKey<V>) -> bool {
+        use subtle::ConstantTimeEq;
+        self.as_bytes().ct_eq(other.as_bytes()).into()
     }
 }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -91,7 +91,7 @@ impl<V> Debug for AsymmetricSecretKey<V> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// An asymmetric public key used for `.public` tokens, given a version `V`.
 pub struct AsymmetricPublicKey<V> {
     pub(crate) bytes: Vec<u8>,

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -333,5 +333,6 @@ mod tests {
         let kpv3 = AsymmetricKeyPair::<V3>::generate().unwrap();
         let pubv3 = AsymmetricPublicKey::<V3>::try_from(&kpv3.secret).unwrap();
         assert_eq!(pubv3.as_bytes(), kpv3.public.as_bytes());
+        assert_eq!(pubv3, kpv3.public);
     }
 }

--- a/src/paserk.rs
+++ b/src/paserk.rs
@@ -228,7 +228,7 @@ impl TryFrom<String> for AsymmetricPublicKey<V4> {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone)]
 /// PASERK IDs.
 ///
 /// This operation calculates the unique ID for a given PASERK.
@@ -237,6 +237,18 @@ impl TryFrom<String> for AsymmetricPublicKey<V4> {
 pub struct Id {
     header: String,
     identifier: String,
+}
+
+impl PartialEq<Id> for Id {
+    fn eq(&self, other: &Id) -> bool {
+        use subtle::ConstantTimeEq;
+        (self.header.as_bytes().ct_eq(other.header.as_bytes())
+            & self
+                .identifier
+                .as_bytes()
+                .ct_eq(other.identifier.as_bytes()))
+        .into()
+    }
 }
 
 impl From<&AsymmetricSecretKey<V3>> for Id {

--- a/src/paserk.rs
+++ b/src/paserk.rs
@@ -228,6 +228,7 @@ impl TryFrom<String> for AsymmetricPublicKey<V4> {
     }
 }
 
+#[derive(Debug, PartialEq, Clone)]
 /// PASERK IDs.
 ///
 /// This operation calculates the unique ID for a given PASERK.


### PR DESCRIPTION
See https://github.com/brycx/pasetors/issues/54

`AsymmetricKeyPair`, `SymmetricKey` and `AsymmetricSecretKey` shouldn't have `Clone` unless a real use-case comes up since they hold secret data.

`LocalToken`/`PublicToken` structs for each given version shouldn't need it because you never actually create and instance of either.

The rest of the types should implement the following traits now at least: `Debug`, `PartialEq` and `Clone`.