### PR TITLE
Improve misuse-resistance by removing public-key as public API parameter in `sign()` operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+### 0.6.0
+
+__Date:__ June 20, 2022.
+
+__Changelog:__
+- PASERK operations are now implemented for `AsymmetricSecretKey<V2>` and `AsymmetricSecretKey<V4>` instead of `AsymmetricKeyPair<V2>` and `AsymmetricKeyPair<V4>`, respectively
+- All `sign()` operations with public tokens now take only the secret key
+- `V2` and `V4` token's `AsymmetricSecretKey<>` are now defined to contain both the Ed25519 secret seed and the public key (see https://github.com/MystenLabs/ed25519-unsafe-libs)
+- `TryFrom<AsymmetricSecretKey<>> for AsymmetricPublicKey<>` is now provided for `V2` and `V4` as well
+
+
 ### 0.5.0
 
 __Date:__ June 4, 2022.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ version = "0.10.2"
 optional = true
 
 [features]
-default = [ "std", "v4", "paserk", "v2" ]
+default = [ "std", "v4", "paserk", "v2", "v3" ]
 std = [ "serde_json", "time", "regex" ]
 v2 = [ "orion", "ed25519-compact" ]
 v3 = [ "rand_core", "p384", "sha2" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pasetors"
-version = "0.5.0" # Update html_root_url in lib.rs along with this.
+version = "0.6.0" # Update html_root_url in lib.rs along with this.
 authors = ["brycx <brycx@protonmail.com>"]
 edition = "2018"
 description = "PASETO: Platform-Agnostic Security Tokens (in Rust)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ version = "0.10.2"
 optional = true
 
 [features]
-default = [ "std", "v4", "paserk" ]
+default = [ "std", "v4", "paserk", "v2" ]
 std = [ "serde_json", "time", "regex" ]
 v2 = [ "orion", "ed25519-compact" ]
 v3 = [ "rand_core", "p384", "sha2" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ version = "0.10.2"
 optional = true
 
 [features]
-default = [ "std", "v4", "paserk", "v2", "v3" ]
+default = [ "std", "v4", "paserk" ]
 std = [ "serde_json", "time", "regex" ]
 v2 = [ "orion", "ed25519-compact" ]
 v3 = [ "rand_core", "p384", "sha2" ]

--- a/fuzz/fuzz_targets/fuzz_paserk.rs
+++ b/fuzz/fuzz_targets/fuzz_paserk.rs
@@ -10,7 +10,7 @@ use pasetors::{version2::V2, version3::V3, version4::V4};
 fuzz_target!(|data: &[u8]| {
     let data: String = String::from_utf8_lossy(data).into();
 
-    if let Ok(valid_paserk) = AsymmetricKeyPair::<V2>::try_from(data.as_str()) {
+    if let Ok(valid_paserk) = AsymmetricSecretKey::<V2>::try_from(data.as_str()) {
         let mut buf = String::new();
         valid_paserk.fmt(&mut buf).unwrap();
         assert_eq!(&data, &buf);
@@ -22,7 +22,7 @@ fuzz_target!(|data: &[u8]| {
         assert_eq!(&data, &buf);
         let _ = Id::from(&valid_paserk);
     }
-    if let Ok(valid_paserk) = AsymmetricKeyPair::<V4>::try_from(data.as_str()) {
+    if let Ok(valid_paserk) = AsymmetricSecretKey::<V4>::try_from(data.as_str()) {
         let mut buf = String::new();
         valid_paserk.fmt(&mut buf).unwrap();
         assert_eq!(&data, &buf);

--- a/fuzz/fuzz_targets/fuzz_pasetors.rs
+++ b/fuzz/fuzz_targets/fuzz_pasetors.rs
@@ -21,7 +21,7 @@ fn fuzztest_v2(data: &[u8], csprng: &mut ChaCha20Rng) {
     csprng.fill_bytes(&mut seed_bytes);
     let seed = Seed::from_slice(&seed_bytes).unwrap();
     let keypair: KeyPair = KeyPair::from_seed(seed);
-    let sk = AsymmetricSecretKey::<V2>::from(&keypair.sk[..32]).unwrap();
+    let sk = AsymmetricSecretKey::<V2>::from(keypair.sk.as_ref()).unwrap();
     let pk = AsymmetricPublicKey::<V2>::from(keypair.pk.as_ref()).unwrap();
     let mut key = [0u8; 32];
     csprng.fill_bytes(&mut key);
@@ -39,7 +39,7 @@ fn fuzztest_v2(data: &[u8], csprng: &mut ChaCha20Rng) {
     }
 
     let public_token = UntrustedToken::<Public, V2>::try_from(
-        &version2::PublicToken::sign(&sk, &pk, message.as_bytes(), None).unwrap(),
+        &version2::PublicToken::sign(&sk, message.as_bytes(), None).unwrap(),
     )
     .unwrap();
     match version2::PublicToken::verify(&pk, &public_token, None) {
@@ -87,7 +87,7 @@ fn fuzztest_v3(data: &[u8]) {
     }
 
     let public_token = UntrustedToken::<Public, V3>::try_from(
-        &version3::PublicToken::sign(&kp.secret, &kp.public, message.as_bytes(), None, None)
+        &version3::PublicToken::sign(&kp.secret, message.as_bytes(), None, None)
             .unwrap(),
     )
     .unwrap();
@@ -106,7 +106,7 @@ fn fuzztest_v4(data: &[u8], csprng: &mut ChaCha20Rng) {
     csprng.fill_bytes(&mut seed_bytes);
     let seed = Seed::from_slice(&seed_bytes).unwrap();
     let keypair: KeyPair = KeyPair::from_seed(seed);
-    let sk = AsymmetricSecretKey::<V4>::from(&keypair.sk[..32]).unwrap();
+    let sk = AsymmetricSecretKey::<V4>::from(keypair.sk.as_ref()).unwrap();
     let pk = AsymmetricPublicKey::<V4>::from(keypair.pk.as_ref()).unwrap();
     let mut key = [0u8; 32];
     csprng.fill_bytes(&mut key);
@@ -124,7 +124,7 @@ fn fuzztest_v4(data: &[u8], csprng: &mut ChaCha20Rng) {
     }
 
     let public_token = UntrustedToken::<Public, V4>::try_from(
-        &version4::PublicToken::sign(&sk, &pk, message.as_bytes(), None, None).unwrap(),
+        &version4::PublicToken::sign(&sk, message.as_bytes(), None, None).unwrap(),
     )
     .unwrap();
     match version4::PublicToken::verify(&pk, &public_token, None, None) {
@@ -161,7 +161,7 @@ fn fuzz_highlevel(data: &[u8], csprng: &mut ChaCha20Rng) {
     csprng.fill_bytes(&mut seed_bytes);
     let seed = Seed::from_slice(&seed_bytes).unwrap();
     let keypair: KeyPair = KeyPair::from_seed(seed);
-    let sk = AsymmetricSecretKey::<V4>::from(&keypair.sk[..32]).unwrap();
+    let sk = AsymmetricSecretKey::<V4>::from(keypair.sk.as_ref()).unwrap();
     let pk = AsymmetricPublicKey::<V4>::from(keypair.pk.as_ref()).unwrap();
     let mut key = [0u8; 32];
     csprng.fill_bytes(&mut key);
@@ -177,7 +177,7 @@ fn fuzz_highlevel(data: &[u8], csprng: &mut ChaCha20Rng) {
     let validation_rules = ClaimsValidationRules::new();
 
     let public_token = UntrustedToken::<Public, V4>::try_from(
-        &pasetors::public::sign(&sk, &pk, &claims, None, None).unwrap(),
+        &pasetors::public::sign(&sk, &claims, None, None).unwrap(),
     )
     .unwrap();
     if let Ok(trusted_token) =

--- a/src/footer.rs
+++ b/src/footer.rs
@@ -256,7 +256,7 @@ mod tests {
         let skv4 = SymmetricKey::<V4>::generate().unwrap();
 
         let mut buf = String::new();
-        kpv2.fmt(&mut buf).unwrap();
+        kpv2.secret.fmt(&mut buf).unwrap();
         assert!(footer.add_additional("wpk", &buf).is_err());
         assert!(footer.add_additional("kid", &buf).is_err());
         assert!(footer.add_additional("custom", &buf).is_err());
@@ -280,7 +280,7 @@ mod tests {
         assert!(footer.add_additional("custom", &buf).is_err());
 
         let mut buf = String::new();
-        kpv4.fmt(&mut buf).unwrap();
+        kpv4.secret.fmt(&mut buf).unwrap();
         assert!(footer.add_additional("wpk", &buf).is_err());
         assert!(footer.add_additional("kid", &buf).is_err());
         assert!(footer.add_additional("custom", &buf).is_err());
@@ -322,7 +322,7 @@ mod tests {
         let skv4 = SymmetricKey::<V4>::generate().unwrap();
 
         let mut buf = String::new();
-        let paserk_id = Id::from(&kpv2);
+        let paserk_id = Id::from(&kpv2.secret);
         paserk_id.fmt(&mut buf).unwrap();
         assert!(footer.add_additional("kid", &buf).is_err());
         assert!(footer.add_additional("custom", &buf).is_ok());
@@ -358,7 +358,7 @@ mod tests {
         assert_eq!(footer.get_claim("kid").unwrap().as_str().unwrap(), buf);
 
         let mut buf = String::new();
-        let paserk_id = Id::from(&kpv4);
+        let paserk_id = Id::from(&kpv4.secret);
         paserk_id.fmt(&mut buf).unwrap();
         assert!(footer.add_additional("kid", &buf).is_err());
         assert!(footer.add_additional("custom", &buf).is_ok());

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -55,7 +55,7 @@ impl<V: Version> PartialEq<SymmetricKey<V>> for SymmetricKey<V> {
 
 /// An asymmetric secret key used for `.public` tokens, given a version `V`.
 ///
-/// In case of Ed25519, which is used in V2 and V4, this is the seed.
+/// In case of Ed25519, which is used in V2 and V4, this is the seed concantenarted with the public key.
 pub struct AsymmetricSecretKey<V> {
     pub(crate) bytes: Vec<u8>,
     pub(crate) phantom: PhantomData<V>,

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -55,7 +55,7 @@ impl<V: Version> PartialEq<SymmetricKey<V>> for SymmetricKey<V> {
 
 /// An asymmetric secret key used for `.public` tokens, given a version `V`.
 ///
-/// In case of Ed25519, which is used in V2 and V4, this is the seed concantenarted with the public key.
+/// In case of Ed25519, which is used in V2 and V4, this is the seed concatenated with the public key.
 pub struct AsymmetricSecretKey<V> {
     pub(crate) bytes: Vec<u8>,
     pub(crate) phantom: PhantomData<V>,

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -54,6 +54,8 @@ impl<V: Version> PartialEq<SymmetricKey<V>> for SymmetricKey<V> {
 }
 
 /// An asymmetric secret key used for `.public` tokens, given a version `V`.
+///
+/// In case of Ed25519, which is used in V2 and V4, this is the seed.
 pub struct AsymmetricSecretKey<V> {
     pub(crate) bytes: Vec<u8>,
     pub(crate) phantom: PhantomData<V>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@
     unused_qualifications,
     overflowing_literals
 )]
-#![doc(html_root_url = "https://docs.rs/pasetors/0.5.0")]
+#![doc(html_root_url = "https://docs.rs/pasetors/0.6.0")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! // Generate the keys and sign the claims.
 //! let kp = AsymmetricKeyPair::<V4>::generate()?;
-//! let pub_token = public::sign(&kp.secret, &kp.public, &claims, None, Some(b"implicit assertion"))?;
+//! let pub_token = public::sign(&kp.secret, &claims, None, Some(b"implicit assertion"))?;
 //!
 //! // Decide how we want to validate the claims after verifying the token itself.
 //! // The default verifies the `nbf`, `iat` and `exp` claims. `nbf` and `iat` are always
@@ -141,7 +141,7 @@
 //! footer.add_additional("custom_footer_claim", "custom_value")?;
 //!
 //! let mut claims = Claims::new()?;
-//! let pub_token = public::sign(&kp.secret, &kp.public, &claims, Some(&footer), Some(b"implicit assertion"))?;
+//! let pub_token = public::sign(&kp.secret, &claims, Some(&footer), Some(b"implicit assertion"))?;
 //!
 //! // If we receive a token that needs to be verified, we can still try to parse a Footer from it
 //! // as long one was used during creation, if we don't know it beforehand.
@@ -246,7 +246,6 @@ pub mod public {
     /// Create a public token using the latest PASETO version (v4).
     pub fn sign(
         secret_key: &AsymmetricSecretKey<V4>,
-        public_key: &AsymmetricPublicKey<V4>,
         message: &Claims,
         footer: Option<&Footer>,
         implicit_assert: Option<&[u8]>,
@@ -254,14 +253,12 @@ pub mod public {
         match footer {
             Some(f) => crate::version4::PublicToken::sign(
                 secret_key,
-                public_key,
                 message.to_string()?.as_bytes(),
                 Some(f.to_string()?.as_bytes()),
                 implicit_assert,
             ),
             None => crate::version4::PublicToken::sign(
                 secret_key,
-                public_key,
                 message.to_string()?.as_bytes(),
                 None,
                 implicit_assert,

--- a/src/version2.rs
+++ b/src/version2.rs
@@ -827,12 +827,4 @@ impl AsymmetricKeyPair<V2> {
             public: AsymmetricPublicKey::from(&bytes[V2::SECRET_KEY..])?,
         })
     }
-
-    pub(crate) fn as_bytes<'a>(&self) -> [u8; 96] {
-        let mut buf = [0u8; V2::SECRET_KEY + V2::PUBLIC_KEY];
-        buf[..V2::SECRET_KEY].copy_from_slice(&self.secret.as_bytes());
-        buf[V2::SECRET_KEY..].copy_from_slice(self.public.as_bytes());
-
-        buf
-    }
 }

--- a/src/version3.rs
+++ b/src/version3.rs
@@ -778,7 +778,7 @@ mod test_keys {
     }
 
     #[test]
-    fn try_from_secret_to_public_v3() {
+    fn try_from_secret_to_public() {
         let kpv3 = AsymmetricKeyPair::<V3>::generate().unwrap();
         let pubv3 = AsymmetricPublicKey::<V3>::try_from(&kpv3.secret).unwrap();
         assert_eq!(pubv3.as_bytes(), kpv3.public.as_bytes());

--- a/src/version3.rs
+++ b/src/version3.rs
@@ -154,10 +154,9 @@ impl PublicToken {
 
     /// Create a public token.
     ///
-    /// The `secret_key` and `public_key` **must** be in big-endian.
+    /// The `secret_key` **must** be in big-endian.
     pub fn sign(
         secret_key: &AsymmetricSecretKey<V3>,
-        public_key: &AsymmetricPublicKey<V3>,
         message: &[u8],
         footer: Option<&[u8]>,
         implicit_assert: Option<&[u8]>,
@@ -167,16 +166,11 @@ impl PublicToken {
         }
 
         let signing_key = SigningKey::from_bytes(secret_key.as_bytes()).map_err(|_| Error::Key)?;
+        let public_key = VerifyingKey::from(&signing_key).to_encoded_point(true);
 
         let f = footer.unwrap_or(&[]);
         let i = implicit_assert.unwrap_or(&[]);
-        let m2 = pae::pae(&[
-            public_key.as_bytes(),
-            Self::HEADER.as_bytes(),
-            message,
-            f,
-            i,
-        ])?;
+        let m2 = pae::pae(&[public_key.as_ref(), Self::HEADER.as_bytes(), message, f, i])?;
 
         let mut msg_digest = sha2::Sha384::new();
         msg_digest.update(m2);
@@ -335,8 +329,7 @@ mod test_vectors {
         let message = "this is a signed message";
 
         let token = UntrustedToken::<Public, V3>::try_from(
-            &PublicToken::sign(&sk, &pk, message.as_bytes(), Some(b"footer"), Some(b"impl"))
-                .unwrap(),
+            &PublicToken::sign(&sk, message.as_bytes(), Some(b"footer"), Some(b"impl")).unwrap(),
         )
         .unwrap();
         assert!(PublicToken::verify(&pk, &token, Some(b"footer"), Some(b"impl")).is_ok());
@@ -378,7 +371,7 @@ mod test_vectors {
 
         let message = test.payload.as_ref().unwrap().as_str().unwrap();
         let actual =
-            PublicToken::sign(&sk, &pk, message.as_bytes(), footer, Some(implicit_assert)).unwrap();
+            PublicToken::sign(&sk, message.as_bytes(), footer, Some(implicit_assert)).unwrap();
         assert_eq!(actual, test.token, "Failed {:?}", test.name);
         let ut = UntrustedToken::<Public, V3>::try_from(&test.token).unwrap();
 
@@ -533,8 +526,7 @@ mod test_tokens {
     fn test_gen_keypair() {
         let kp = AsymmetricKeyPair::<V3>::generate().unwrap();
 
-        let token =
-            PublicToken::sign(&kp.secret, &kp.public, MESSAGE.as_bytes(), None, None).unwrap();
+        let token = PublicToken::sign(&kp.secret, MESSAGE.as_bytes(), None, None).unwrap();
 
         let ut = UntrustedToken::<Public, V3>::try_from(&token).unwrap();
         assert!(PublicToken::verify(&kp.public, &ut, None, None).is_ok());
@@ -546,7 +538,6 @@ mod test_tokens {
         let kp = AsymmetricKeyPair::<V3>::generate().unwrap();
         let token = PublicToken::sign(
             &kp.secret,
-            &kp.public,
             MESSAGE.as_bytes(),
             Some(FOOTER.as_bytes()),
             None,
@@ -568,7 +559,7 @@ mod test_tokens {
         let test_sk = AsymmetricSecretKey::<V3>::from(&TEST_SK_BYTES).unwrap();
         let test_pk = AsymmetricPublicKey::<V3>::from(&TEST_PK_BYTES).unwrap();
 
-        let token = PublicToken::sign(&test_sk, &test_pk, MESSAGE.as_bytes(), None, None).unwrap();
+        let token = PublicToken::sign(&test_sk, MESSAGE.as_bytes(), None, None).unwrap();
         let ut = UntrustedToken::<Public, V3>::try_from(&token).unwrap();
 
         assert!(PublicToken::verify(&test_pk, &ut, None, None).is_ok());
@@ -583,11 +574,11 @@ mod test_tokens {
 
         // We create a token with Some(footer) and with None
         let actual_some = UntrustedToken::<Public, V3>::try_from(
-            &PublicToken::sign(&test_sk, &test_pk, message, Some(FOOTER.as_bytes()), None).unwrap(),
+            &PublicToken::sign(&test_sk, message, Some(FOOTER.as_bytes()), None).unwrap(),
         )
         .unwrap();
         let actual_none = UntrustedToken::<Public, V3>::try_from(
-            &PublicToken::sign(&test_sk, &test_pk, message, None, None).unwrap(),
+            &PublicToken::sign(&test_sk, message, None, None).unwrap(),
         )
         .unwrap();
 
@@ -614,11 +605,11 @@ mod test_tokens {
         let implicit = b"";
 
         let actual_some = UntrustedToken::<Public, V3>::try_from(
-            &PublicToken::sign(&test_sk, &test_pk, message, None, Some(implicit)).unwrap(),
+            &PublicToken::sign(&test_sk, message, None, Some(implicit)).unwrap(),
         )
         .unwrap();
         let actual_none = UntrustedToken::<Public, V3>::try_from(
-            &PublicToken::sign(&test_sk, &test_pk, message, None, None).unwrap(),
+            &PublicToken::sign(&test_sk, message, None, None).unwrap(),
         )
         .unwrap();
 
@@ -630,10 +621,9 @@ mod test_tokens {
     // NOTE: See https://github.com/paseto-standard/paseto-spec/issues/17
     fn empty_payload() {
         let test_sk = AsymmetricSecretKey::<V3>::from(&TEST_SK_BYTES).unwrap();
-        let test_pk = AsymmetricPublicKey::<V3>::from(&TEST_PK_BYTES).unwrap();
 
         assert_eq!(
-            PublicToken::sign(&test_sk, &test_pk, b"", None, None).unwrap_err(),
+            PublicToken::sign(&test_sk, b"", None, None).unwrap_err(),
             Error::EmptyPayload
         );
     }

--- a/src/version4.rs
+++ b/src/version4.rs
@@ -910,6 +910,7 @@ mod test_tokens {
 
 #[cfg(test)]
 mod test_keys {
+    use crate::common::decode_b64;
     use super::*;
 
     #[test]
@@ -948,6 +949,26 @@ mod test_keys {
         let randomv = AsymmetricKeyPair::<V4>::generate().unwrap();
         let zero = AsymmetricKeyPair::<V4>::from(&[0u8; V4::SECRET_KEY + V4::PUBLIC_KEY]).unwrap();
         assert_ne!(randomv.secret, zero.secret);
+    }
+
+    #[test]
+    fn double_pubkey_attack() {
+        let kp1 = AsymmetricKeyPair::<V4>::generate().unwrap();
+        let kp2 = AsymmetricKeyPair::<V4>::generate().unwrap();
+
+        let tok1 = PublicToken::sign(&kp1.secret, &kp1.public, "Hello World".as_bytes(), None, None).unwrap();
+        let tok2 = PublicToken::sign(&kp1.secret, &kp2.public, "Hello World".as_bytes(), None, None).unwrap();
+
+        // Token format: HEADER + MSG + SIG
+        let mlen = "Hello World".as_bytes().len();
+
+        let mut sig1 = decode_b64(&tok1.strip_prefix(PublicToken::HEADER).unwrap().as_bytes()).unwrap();
+        sig1 = sig1[mlen..mlen+32].to_vec();
+
+        let mut sig2 = decode_b64(&tok2.strip_prefix(PublicToken::HEADER).unwrap().as_bytes()).unwrap();
+        sig2 = sig2[mlen..mlen+32].to_vec();
+
+        assert_ne!(sig1, sig2);
     }
 }
 

--- a/src/version4.rs
+++ b/src/version4.rs
@@ -981,12 +981,4 @@ impl AsymmetricKeyPair<V4> {
             public: AsymmetricPublicKey::from(&bytes[V4::SECRET_KEY..])?,
         })
     }
-
-    pub(crate) fn as_bytes<'a>(&self) -> [u8; 96] {
-        let mut buf = [0u8; V4::SECRET_KEY + V4::PUBLIC_KEY];
-        buf[..V4::SECRET_KEY].copy_from_slice(&self.secret.as_bytes());
-        buf[V4::SECRET_KEY..].copy_from_slice(self.public.as_bytes());
-
-        buf
-    }
 }

--- a/src/version4.rs
+++ b/src/version4.rs
@@ -26,7 +26,7 @@ pub struct V4;
 
 impl Version for V4 {
     const LOCAL_KEY: usize = 32;
-    const SECRET_KEY: usize = 64; // Secretkey + Seed
+    const SECRET_KEY: usize = 32 + Self::PUBLIC_KEY; // Seed || PK
     const PUBLIC_KEY: usize = 32;
     const PUBLIC_SIG: usize = 64;
     const LOCAL_NONCE: usize = 32;
@@ -63,7 +63,7 @@ impl Generate<AsymmetricKeyPair<V4>, V4> for AsymmetricKeyPair<V4> {
     fn generate() -> Result<AsymmetricKeyPair<V4>, Error> {
         let key_pair = KeyPair::generate();
 
-        let secret = AsymmetricSecretKey::<V4>::from(&key_pair.sk.as_ref())
+        let secret = AsymmetricSecretKey::<V4>::from(key_pair.sk.as_ref())
             .map_err(|_| Error::KeyGeneration)?;
         let public = AsymmetricPublicKey::<V4>::from(key_pair.pk.as_ref())
             .map_err(|_| Error::KeyGeneration)?;
@@ -434,13 +434,6 @@ mod test_vectors {
     }
 }
 
-#[test]
-fn display() {
-    println!("{:?}", &hex::decode("b4cbfb43df4ce210727d953e4a713307fa19bb7d9f85041438d9e11b942a37741eb9dbbbbc047c03fd70604e0071f0987e16b28b757225c11f00415d0e20b1a2").unwrap());
-
-    // b4cbfb43df4ce210727d953e4a713307fa19bb7d9f85041438d9e11b942a37741eb9dbbbbc047c03fd70604e0071f0987e16b28b757225c11f00415d0e20b1a2
-}
-
 #[cfg(test)]
 mod test_tokens {
     use super::*;
@@ -449,16 +442,16 @@ mod test_tokens {
     use crate::token::UntrustedToken;
     use core::convert::TryFrom;
 
-    // In version 2 tests, the SK used for public tokens is valid for the local as well.
-    // Not the case with version 4.
     const TEST_LOCAL_SK_BYTES: [u8; 32] = [
         112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129,
         130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143,
     ];
 
-    const TEST_SK_BYTES: [u8; 32] = [
+    const TEST_SK_BYTES: [u8; 64] = [
         180, 203, 251, 67, 223, 76, 226, 16, 114, 125, 149, 62, 74, 113, 51, 7, 250, 25, 187, 125,
-        159, 133, 4, 20, 56, 217, 225, 27, 148, 42, 55, 116,
+        159, 133, 4, 20, 56, 217, 225, 27, 148, 42, 55, 116, 30, 185, 219, 187, 188, 4, 124, 3,
+        253, 112, 96, 78, 0, 113, 240, 152, 126, 22, 178, 139, 117, 114, 37, 193, 31, 0, 65, 93,
+        14, 32, 177, 162,
     ];
 
     const TEST_PK_BYTES: [u8; 32] = [
@@ -540,7 +533,7 @@ mod test_tokens {
 
     #[test]
     fn footer_logic() {
-        let test_local_sk = SymmetricKey::<V4>::from(&TEST_SK_BYTES).unwrap();
+        let test_local_sk = SymmetricKey::<V4>::from(&TEST_LOCAL_SK_BYTES).unwrap();
         let test_sk = AsymmetricSecretKey::<V4>::from(&TEST_SK_BYTES).unwrap();
         let test_pk = AsymmetricPublicKey::<V4>::from(&TEST_PK_BYTES).unwrap();
         let message =
@@ -592,7 +585,7 @@ mod test_tokens {
 
     #[test]
     fn implicit_none_some_empty_is_same() {
-        let test_local_sk = SymmetricKey::<V4>::from(&TEST_SK_BYTES).unwrap();
+        let test_local_sk = SymmetricKey::<V4>::from(&TEST_LOCAL_SK_BYTES).unwrap();
         let test_sk = AsymmetricSecretKey::<V4>::from(&TEST_SK_BYTES).unwrap();
         let test_pk = AsymmetricPublicKey::<V4>::from(&TEST_PK_BYTES).unwrap();
         let message =
@@ -629,9 +622,8 @@ mod test_tokens {
     #[test]
     // NOTE: See https://github.com/paseto-standard/paseto-spec/issues/17
     fn empty_payload() {
-        let test_local_sk = SymmetricKey::<V4>::from(&TEST_SK_BYTES).unwrap();
+        let test_local_sk = SymmetricKey::<V4>::from(&TEST_LOCAL_SK_BYTES).unwrap();
         let test_sk = AsymmetricSecretKey::<V4>::from(&TEST_SK_BYTES).unwrap();
-        let test_pk = AsymmetricPublicKey::<V4>::from(&TEST_PK_BYTES).unwrap();
 
         assert_eq!(
             PublicToken::sign(&test_sk, b"", None, None).unwrap_err(),
@@ -917,7 +909,6 @@ mod test_tokens {
 #[cfg(test)]
 mod test_keys {
     use super::*;
-    use crate::common::decode_b64;
 
     #[test]
     fn test_symmetric_gen() {
@@ -927,9 +918,9 @@ mod test_keys {
 
     #[test]
     fn test_invalid_sizes() {
-        assert!(AsymmetricSecretKey::<V4>::from(&[0u8; 31]).is_err());
-        assert!(AsymmetricSecretKey::<V4>::from(&[0u8; 32]).is_ok());
-        assert!(AsymmetricSecretKey::<V4>::from(&[0u8; 33]).is_err());
+        assert!(AsymmetricSecretKey::<V4>::from(&[0u8; 63]).is_err());
+        assert!(AsymmetricSecretKey::<V4>::from(&[0u8; 64]).is_ok());
+        assert!(AsymmetricSecretKey::<V4>::from(&[0u8; 65]).is_err());
 
         assert!(AsymmetricPublicKey::<V4>::from(&[0u8; 31]).is_err());
         assert!(AsymmetricPublicKey::<V4>::from(&[0u8; 32]).is_ok());
@@ -956,28 +947,6 @@ mod test_keys {
         let zero = AsymmetricKeyPair::<V4>::from(&[0u8; V4::SECRET_KEY + V4::PUBLIC_KEY]).unwrap();
         assert_ne!(randomv.secret, zero.secret);
     }
-
-    #[test]
-    fn double_pubkey_attack() {
-        let kp1 = AsymmetricKeyPair::<V4>::generate().unwrap();
-        let kp2 = AsymmetricKeyPair::<V4>::generate().unwrap();
-
-        let tok1 = PublicToken::sign(&kp1.secret, "Hello World".as_bytes(), None, None).unwrap();
-        let tok2 = PublicToken::sign(&kp1.secret, "Hello World".as_bytes(), None, None).unwrap();
-
-        // Token format: HEADER + MSG + SIG
-        let mlen = "Hello World".as_bytes().len();
-
-        let mut sig1 =
-            decode_b64(&tok1.strip_prefix(PublicToken::HEADER).unwrap().as_bytes()).unwrap();
-        sig1 = sig1[mlen..mlen + 32].to_vec();
-
-        let mut sig2 =
-            decode_b64(&tok2.strip_prefix(PublicToken::HEADER).unwrap().as_bytes()).unwrap();
-        sig2 = sig2[mlen..mlen + 32].to_vec();
-
-        assert_ne!(sig1, sig2);
-    }
 }
 
 #[cfg(test)]
@@ -995,9 +964,9 @@ impl AsymmetricKeyPair<V4> {
         })
     }
 
-    pub(crate) fn as_bytes<'a>(&self) -> [u8; 64] {
+    pub(crate) fn as_bytes<'a>(&self) -> [u8; 96] {
         let mut buf = [0u8; V4::SECRET_KEY + V4::PUBLIC_KEY];
-        buf[..V4::SECRET_KEY].copy_from_slice(&self.secret.as_bytes()[..32]);
+        buf[..V4::SECRET_KEY].copy_from_slice(&self.secret.as_bytes());
         buf[V4::SECRET_KEY..].copy_from_slice(self.public.as_bytes());
 
         buf


### PR DESCRIPTION
See: https://github.com/MystenLabs/ed25519-unsafe-libs