### PR TITLE
Address clippy lints in tests

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -30,4 +30,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --all-features --all-targets -- -D warnings

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -450,17 +450,17 @@ mod test {
         let mut claims = Claims::new().unwrap();
 
         // Default claims
-        assert_eq!(claims.contains_claim("iat"), true);
-        assert_eq!(claims.contains_claim("nbf"), true);
-        assert_eq!(claims.contains_claim("exp"), true);
+        assert!(claims.contains_claim("iat"));
+        assert!(claims.contains_claim("nbf"));
+        assert!(claims.contains_claim("exp"));
 
-        assert_eq!(claims.contains_claim("iss"), false);
+        assert!(!claims.contains_claim("iss"));
         claims.issuer("testIssuer").unwrap();
-        assert_eq!(claims.contains_claim("iss"), true);
+        assert!(claims.contains_claim("iss"));
 
-        assert_eq!(claims.contains_claim("aud"), false);
+        assert!(!claims.contains_claim("aud"));
         claims.audience("testAudience").unwrap();
-        assert_eq!(claims.contains_claim("aud"), true);
+        assert!(claims.contains_claim("aud"));
     }
 
     #[test]
@@ -634,7 +634,7 @@ mod test {
                 .unwrap_err(),
             Error::ClaimValidation
         );
-        future_claims.issued_at(&old_iat.as_str().unwrap()).unwrap();
+        future_claims.issued_at(old_iat.as_str().unwrap()).unwrap();
         assert!(claims_validation.validate_claims(&future_claims).is_ok());
         // Not yet valid
         let old_nbf = future_claims
@@ -669,7 +669,7 @@ mod test {
             Error::ClaimValidation
         );
 
-        let mut incomplete_claims = claims.clone();
+        let mut incomplete_claims = claims;
         incomplete_claims.list_of.remove_entry("nbf").unwrap();
         assert_eq!(
             claims_validation
@@ -720,15 +720,15 @@ mod test {
 
         // Default validation rules validate these times but error if they're missing
         let mut claims = Claims::new().unwrap();
-        claims.list_of.remove("iat".into());
+        claims.list_of.remove("iat");
         assert!(claims_validation.validate_claims(&claims).is_err());
 
         let mut claims = Claims::new().unwrap();
-        claims.list_of.remove("nbf".into());
+        claims.list_of.remove("nbf");
         assert!(claims_validation.validate_claims(&claims).is_err());
 
         let mut claims = Claims::new().unwrap();
-        claims.list_of.remove("exp".into());
+        claims.list_of.remove("exp");
         assert!(claims_validation.validate_claims(&claims).is_err());
     }
 }

--- a/src/pae.rs
+++ b/src/pae.rs
@@ -43,7 +43,6 @@ pub fn pae(pieces: &[&[u8]]) -> Result<Vec<u8>, Error> {
 #[cfg(test)]
 mod unit_tests {
     use super::*;
-    use hex;
 
     #[test]
     fn test_le64() {

--- a/src/token.rs
+++ b/src/token.rs
@@ -280,13 +280,13 @@ mod tests_untrusted {
     use crate::version::private::Version;
     use crate::{version2::V2, version3::V3, version4::V4};
 
-    const V2_PUBLIC_TOKEN: &'static str = "v2.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAxOS0wMS0wMVQwMDowMDowMCswMDowMCJ9flsZsx_gYCR0N_Ec2QxJFFpvQAs7h9HtKwbVK2n1MJ3Rz-hwe8KUqjnd8FAnIJZ601tp7lGkguU63oGbomhoBw.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
-    const V2_LOCAL_TOKEN: &'static str = "v2.local.5K4SCXNhItIhyNuVIZcwrdtaDKiyF81-eWHScuE0idiVqCo72bbjo07W05mqQkhLZdVbxEa5I_u5sgVk1QLkcWEcOSlLHwNpCkvmGGlbCdNExn6Qclw3qTKIIl5-zSLIrxZqOLwcFLYbVK1SrQ.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
-    const V3_PUBLIC_TOKEN: &'static str = "v3.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9ZWrbGZ6L0MDK72skosUaS0Dz7wJ_2bMcM6tOxFuCasO9GhwHrvvchqgXQNLQQyWzGC2wkr-VKII71AvkLpC8tJOrzJV1cap9NRwoFzbcXjzMZyxQ0wkshxZxx8ImmNWP.eyJraWQiOiJkWWtJU3lseFFlZWNFY0hFTGZ6Rjg4VVpyd2JMb2xOaUNkcHpVSEd3OVVxbiJ9";
-    const V4_PUBLIC_TOKEN: &'static str = "v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9v3Jt8mx_TdM2ceTGoqwrh4yDFn0XsHvvV_D0DtwQxVrJEBMl0F2caAdgnpKlt4p7xBnx1HcO-SPo8FPp214HDw.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
-    const V4_LOCAL_TOKEN: &'static str = "v4.local.32VIErrEkmY4JVILovbmfPXKW9wT1OdQepjMTC_MOtjA4kiqw7_tcaOM5GNEcnTxl60WkwMsYXw6FSNb_UdJPXjpzm0KW9ojM5f4O2mRvE2IcweP-PRdoHjd5-RHCiExR1IK6t4x-RMNXtQNbz7FvFZ_G-lFpk5RG3EOrwDL6CgDqcerSQ.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
+    const V2_PUBLIC_TOKEN: &str = "v2.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAxOS0wMS0wMVQwMDowMDowMCswMDowMCJ9flsZsx_gYCR0N_Ec2QxJFFpvQAs7h9HtKwbVK2n1MJ3Rz-hwe8KUqjnd8FAnIJZ601tp7lGkguU63oGbomhoBw.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
+    const V2_LOCAL_TOKEN: &str = "v2.local.5K4SCXNhItIhyNuVIZcwrdtaDKiyF81-eWHScuE0idiVqCo72bbjo07W05mqQkhLZdVbxEa5I_u5sgVk1QLkcWEcOSlLHwNpCkvmGGlbCdNExn6Qclw3qTKIIl5-zSLIrxZqOLwcFLYbVK1SrQ.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
+    const V3_PUBLIC_TOKEN: &str = "v3.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9ZWrbGZ6L0MDK72skosUaS0Dz7wJ_2bMcM6tOxFuCasO9GhwHrvvchqgXQNLQQyWzGC2wkr-VKII71AvkLpC8tJOrzJV1cap9NRwoFzbcXjzMZyxQ0wkshxZxx8ImmNWP.eyJraWQiOiJkWWtJU3lseFFlZWNFY0hFTGZ6Rjg4VVpyd2JMb2xOaUNkcHpVSEd3OVVxbiJ9";
+    const V4_PUBLIC_TOKEN: &str = "v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9v3Jt8mx_TdM2ceTGoqwrh4yDFn0XsHvvV_D0DtwQxVrJEBMl0F2caAdgnpKlt4p7xBnx1HcO-SPo8FPp214HDw.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
+    const V4_LOCAL_TOKEN: &str = "v4.local.32VIErrEkmY4JVILovbmfPXKW9wT1OdQepjMTC_MOtjA4kiqw7_tcaOM5GNEcnTxl60WkwMsYXw6FSNb_UdJPXjpzm0KW9ojM5f4O2mRvE2IcweP-PRdoHjd5-RHCiExR1IK6t4x-RMNXtQNbz7FvFZ_G-lFpk5RG3EOrwDL6CgDqcerSQ.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
 
-    const TOKEN_LIST: [&'static str; 5] = [
+    const TOKEN_LIST: [&str; 5] = [
         V2_PUBLIC_TOKEN,
         V2_LOCAL_TOKEN,
         V3_PUBLIC_TOKEN,
@@ -365,7 +365,7 @@ mod tests_untrusted {
     fn no_separators() {
         for token in TOKEN_LIST {
             let split = token.split('.').collect::<Vec<&str>>();
-            let invalid: String = split.iter().map(|x| *x).collect();
+            let invalid: String = split.iter().copied().collect();
 
             test_untrusted_parse_fails(&invalid, Error::TokenFormat);
         }
@@ -402,7 +402,7 @@ mod tests_untrusted {
     fn extra_after_footer() {
         for token in TOKEN_LIST {
             let mut invalid = token.to_string();
-            invalid.extend(".shouldNotBeHere".chars());
+            invalid.push_str(".shouldNotBeHere");
 
             test_untrusted_parse_fails(&invalid, Error::TokenFormat);
         }

--- a/src/version3.rs
+++ b/src/version3.rs
@@ -359,11 +359,8 @@ mod test_vectors {
 
         // payload is null when we expect failure
         if test.expect_fail {
-            match UntrustedToken::<Public, V3>::try_from(&test.token) {
-                Ok(ut) => {
-                    assert!(PublicToken::verify(&pk, &ut, footer, Some(implicit_assert)).is_err());
-                }
-                Err(_) => (),
+            if let Ok(ut) = UntrustedToken::<Public, V3>::try_from(&test.token) {
+                assert!(PublicToken::verify(&pk, &ut, footer, Some(implicit_assert)).is_err());
             }
 
             return;
@@ -517,10 +514,10 @@ mod test_tokens {
         105, 158, 163, 14, 114, 135, 76, 114, 251,
     ];
 
-    const MESSAGE: &'static str =
+    const MESSAGE: &str =
         "{\"data\":\"this is a signed message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}";
-    const FOOTER: &'static str = "{\"kid\":\"dYkISylxQeecEcHELfzF88UZrwbLolNiCdpzUHGw9Uqn\"}";
-    const VALID_PUBLIC_TOKEN: &'static str = "v3.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9ZWrbGZ6L0MDK72skosUaS0Dz7wJ_2bMcM6tOxFuCasO9GhwHrvvchqgXQNLQQyWzGC2wkr-VKII71AvkLpC8tJOrzJV1cap9NRwoFzbcXjzMZyxQ0wkshxZxx8ImmNWP.eyJraWQiOiJkWWtJU3lseFFlZWNFY0hFTGZ6Rjg4VVpyd2JMb2xOaUNkcHpVSEd3OVVxbiJ9";
+    const FOOTER: &str = "{\"kid\":\"dYkISylxQeecEcHELfzF88UZrwbLolNiCdpzUHGw9Uqn\"}";
+    const VALID_PUBLIC_TOKEN: &str = "v3.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9ZWrbGZ6L0MDK72skosUaS0Dz7wJ_2bMcM6tOxFuCasO9GhwHrvvchqgXQNLQQyWzGC2wkr-VKII71AvkLpC8tJOrzJV1cap9NRwoFzbcXjzMZyxQ0wkshxZxx8ImmNWP.eyJraWQiOiJkWWtJU3lseFFlZWNFY0hFTGZ6Rjg4VVpyd2JMb2xOaUNkcHpVSEd3OVVxbiJ9";
 
     #[test]
     fn test_gen_keypair() {
@@ -636,7 +633,7 @@ mod test_tokens {
             PublicToken::verify(
                 &test_pk,
                 &UntrustedToken::<Public, V3>::try_from(VALID_PUBLIC_TOKEN).unwrap(),
-                Some(&FOOTER.replace("kid", "mid").as_bytes()),
+                Some(FOOTER.replace("kid", "mid").as_bytes()),
                 None
             )
             .unwrap_err(),
@@ -709,7 +706,7 @@ mod test_tokens {
         let test_pk = AsymmetricPublicKey::<V3>::from(&TEST_PK_BYTES).unwrap();
 
         let mut split_public = VALID_PUBLIC_TOKEN.split('.').collect::<Vec<&str>>();
-        let mut bad_sig = Vec::from(decode_b64(split_public[2]).unwrap());
+        let mut bad_sig = decode_b64(split_public[2]).unwrap();
         bad_sig.copy_within(0..32, 32);
         let tmp = encode_b64(bad_sig).unwrap();
         split_public[2] = &tmp;

--- a/src/version4.rs
+++ b/src/version4.rs
@@ -336,11 +336,8 @@ mod test_vectors {
 
         // payload is null when we expect failure
         if test.expect_fail {
-            match UntrustedToken::<Local, V4>::try_from(&test.token) {
-                Ok(ut) => {
-                    assert!(LocalToken::decrypt(&sk, &ut, footer, Some(implicit_assert)).is_err());
-                }
-                Err(_) => (),
+            if let Ok(ut) = UntrustedToken::<Local, V4>::try_from(&test.token) {
+                assert!(LocalToken::decrypt(&sk, &ut, footer, Some(implicit_assert)).is_err());
             }
 
             return;
@@ -365,7 +362,7 @@ mod test_vectors {
         assert_eq!(trusted.header(), LocalToken::HEADER);
         assert_eq!(trusted.implicit_assert(), implicit_assert);
 
-        let parsed_claims = Claims::from_bytes(&trusted.payload().as_bytes()).unwrap();
+        let parsed_claims = Claims::from_bytes(trusted.payload().as_bytes()).unwrap();
         let test_vector_claims = serde_json::from_str::<Payload>(message).unwrap();
 
         assert_eq!(
@@ -399,11 +396,8 @@ mod test_vectors {
 
         // payload is null when we expect failure
         if test.expect_fail {
-            match UntrustedToken::<Public, V4>::try_from(&test.token) {
-                Ok(ut) => {
-                    assert!(PublicToken::verify(&pk, &ut, footer, Some(implicit_assert)).is_err());
-                }
-                Err(_) => (),
+            if let Ok(ut) = UntrustedToken::<Public, V4>::try_from(&test.token) {
+                assert!(PublicToken::verify(&pk, &ut, footer, Some(implicit_assert)).is_err());
             }
 
             return;
@@ -468,11 +462,11 @@ mod test_tokens {
         117, 114, 37, 193, 31, 0, 65, 93, 14, 32, 177, 162,
     ];
 
-    const MESSAGE: &'static str =
+    const MESSAGE: &str =
         "{\"data\":\"this is a signed message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}";
-    const FOOTER: &'static str = "{\"kid\":\"zVhMiPBP9fRf2snEcT7gFTioeA9COcNy9DfgL1W60haN\"}";
-    const VALID_PUBLIC_TOKEN: &'static str = "v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9v3Jt8mx_TdM2ceTGoqwrh4yDFn0XsHvvV_D0DtwQxVrJEBMl0F2caAdgnpKlt4p7xBnx1HcO-SPo8FPp214HDw.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
-    const VALID_LOCAL_TOKEN: &'static str = "v4.local.32VIErrEkmY4JVILovbmfPXKW9wT1OdQepjMTC_MOtjA4kiqw7_tcaOM5GNEcnTxl60WkwMsYXw6FSNb_UdJPXjpzm0KW9ojM5f4O2mRvE2IcweP-PRdoHjd5-RHCiExR1IK6t4x-RMNXtQNbz7FvFZ_G-lFpk5RG3EOrwDL6CgDqcerSQ.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
+    const FOOTER: &str = "{\"kid\":\"zVhMiPBP9fRf2snEcT7gFTioeA9COcNy9DfgL1W60haN\"}";
+    const VALID_PUBLIC_TOKEN: &str = "v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9v3Jt8mx_TdM2ceTGoqwrh4yDFn0XsHvvV_D0DtwQxVrJEBMl0F2caAdgnpKlt4p7xBnx1HcO-SPo8FPp214HDw.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
+    const VALID_LOCAL_TOKEN: &str = "v4.local.32VIErrEkmY4JVILovbmfPXKW9wT1OdQepjMTC_MOtjA4kiqw7_tcaOM5GNEcnTxl60WkwMsYXw6FSNb_UdJPXjpzm0KW9ojM5f4O2mRvE2IcweP-PRdoHjd5-RHCiExR1IK6t4x-RMNXtQNbz7FvFZ_G-lFpk5RG3EOrwDL6CgDqcerSQ.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9";
 
     #[test]
     fn test_gen_keypair() {
@@ -653,7 +647,7 @@ mod test_tokens {
             PublicToken::verify(
                 &test_pk,
                 &UntrustedToken::<Public, V4>::try_from(VALID_PUBLIC_TOKEN).unwrap(),
-                Some(&FOOTER.replace("kid", "mid").as_bytes()),
+                Some(FOOTER.replace("kid", "mid").as_bytes()),
                 None
             )
             .unwrap_err(),
@@ -663,7 +657,7 @@ mod test_tokens {
             LocalToken::decrypt(
                 &test_local_sk,
                 &UntrustedToken::<Local, V4>::try_from(VALID_LOCAL_TOKEN).unwrap(),
-                Some(&FOOTER.replace("kid", "mid").as_bytes()),
+                Some(FOOTER.replace("kid", "mid").as_bytes()),
                 None
             )
             .unwrap_err(),
@@ -780,7 +774,7 @@ mod test_tokens {
         let test_pk = AsymmetricPublicKey::<V4>::from(&TEST_PK_BYTES).unwrap();
 
         let mut split_public = VALID_PUBLIC_TOKEN.split('.').collect::<Vec<&str>>();
-        let mut bad_sig = Vec::from(decode_b64(split_public[2]).unwrap());
+        let mut bad_sig = decode_b64(split_public[2]).unwrap();
         bad_sig.copy_within(0..32, 32);
         let tmp = encode_b64(bad_sig).unwrap();
         split_public[2] = &tmp;
@@ -806,7 +800,7 @@ mod test_tokens {
         let test_local_sk = SymmetricKey::<V4>::from(&TEST_LOCAL_SK_BYTES).unwrap();
 
         let mut split_local = VALID_LOCAL_TOKEN.split('.').collect::<Vec<&str>>();
-        let mut bad_tag = Vec::from(decode_b64(split_local[2]).unwrap());
+        let mut bad_tag = decode_b64(split_local[2]).unwrap();
         let tlen = bad_tag.len();
         bad_tag.copy_within(0..16, tlen - 16);
         let tmp = encode_b64(bad_tag).unwrap();
@@ -833,7 +827,7 @@ mod test_tokens {
         let test_local_sk = SymmetricKey::<V4>::from(&TEST_LOCAL_SK_BYTES).unwrap();
 
         let mut split_local = VALID_LOCAL_TOKEN.split('.').collect::<Vec<&str>>();
-        let mut bad_ct = Vec::from(decode_b64(split_local[2]).unwrap());
+        let mut bad_ct = decode_b64(split_local[2]).unwrap();
         let ctlen = bad_ct.len();
         bad_ct.copy_within((ctlen - 16)..ctlen, 24);
         let tmp = encode_b64(bad_ct).unwrap();
@@ -860,7 +854,7 @@ mod test_tokens {
         let test_local_sk = SymmetricKey::<V4>::from(&TEST_LOCAL_SK_BYTES).unwrap();
 
         let mut split_local = VALID_LOCAL_TOKEN.split('.').collect::<Vec<&str>>();
-        let mut bad_nonce = Vec::from(decode_b64(split_local[2]).unwrap());
+        let mut bad_nonce = decode_b64(split_local[2]).unwrap();
         let nlen = bad_nonce.len();
         bad_nonce.copy_within((nlen - 24)..nlen, 0);
         let tmp = encode_b64(bad_nonce).unwrap();


### PR DESCRIPTION
Should I also update the [lint workflow](https://github.com/brycx/pasetors/blob/24e0184ea71fff0b0fe972d8051dc41f3958172a/.github/workflows/lints.yml#L33) to run `cargo clippy --all-features --all-targets -- -D warnings` instead?