### PR TITLE
Add optional `serde` support for keys and PASERK IDs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,10 @@ optional = true
 version = "0.10.2"
 optional = true
 
+[dependencies.serde]
+version = "1.0.145"
+optional = true
+
 [features]
 default = [ "std", "v4", "paserk" ]
 std = [ "serde_json", "time", "regex" ]

--- a/fuzz/fuzz_targets/fuzz_paserk.rs
+++ b/fuzz/fuzz_targets/fuzz_paserk.rs
@@ -14,50 +14,82 @@ fuzz_target!(|data: &[u8]| {
         let mut buf = String::new();
         valid_paserk.fmt(&mut buf).unwrap();
         assert_eq!(&data, &buf);
-        let _ = Id::from(&valid_paserk);
+        let id_from_key = Id::from(&valid_paserk);
+        let mut buf = String::new();
+        id_from_key.fmt(&mut buf).unwrap();
+        let id_from_string = Id::try_from(buf.as_str()).unwrap();
+        assert_eq!(id_from_key, id_from_string);
     }
     if let Ok(valid_paserk) = AsymmetricSecretKey::<V3>::try_from(data.as_str()) {
         let mut buf = String::new();
         valid_paserk.fmt(&mut buf).unwrap();
         assert_eq!(&data, &buf);
-        let _ = Id::from(&valid_paserk);
+        let id_from_key = Id::from(&valid_paserk);
+        let mut buf = String::new();
+        id_from_key.fmt(&mut buf).unwrap();
+        let id_from_string = Id::try_from(buf.as_str()).unwrap();
+        assert_eq!(id_from_key, id_from_string);
     }
     if let Ok(valid_paserk) = AsymmetricSecretKey::<V4>::try_from(data.as_str()) {
         let mut buf = String::new();
         valid_paserk.fmt(&mut buf).unwrap();
         assert_eq!(&data, &buf);
-        let _ = Id::from(&valid_paserk);
+        let id_from_key = Id::from(&valid_paserk);
+        let mut buf = String::new();
+        id_from_key.fmt(&mut buf).unwrap();
+        let id_from_string = Id::try_from(buf.as_str()).unwrap();
+        assert_eq!(id_from_key, id_from_string);
     }
 
     if let Ok(valid_paserk) = AsymmetricPublicKey::<V2>::try_from(data.as_str()) {
         let mut buf = String::new();
         valid_paserk.fmt(&mut buf).unwrap();
         assert_eq!(&data, &buf);
-        let _ = Id::from(&valid_paserk);
+        let id_from_key = Id::from(&valid_paserk);
+        let mut buf = String::new();
+        id_from_key.fmt(&mut buf).unwrap();
+        let id_from_string = Id::try_from(buf.as_str()).unwrap();
+        assert_eq!(id_from_key, id_from_string);
     }
     if let Ok(valid_paserk) = AsymmetricPublicKey::<V3>::try_from(data.as_str()) {
         let mut buf = String::new();
         valid_paserk.fmt(&mut buf).unwrap();
         assert_eq!(&data, &buf);
-        let _ = Id::from(&valid_paserk);
+        let id_from_key = Id::from(&valid_paserk);
+        let mut buf = String::new();
+        id_from_key.fmt(&mut buf).unwrap();
+        let id_from_string = Id::try_from(buf.as_str()).unwrap();
+        assert_eq!(id_from_key, id_from_string);
     }
     if let Ok(valid_paserk) = AsymmetricPublicKey::<V4>::try_from(data.as_str()) {
         let mut buf = String::new();
         valid_paserk.fmt(&mut buf).unwrap();
         assert_eq!(&data, &buf);
-        let _ = Id::from(&valid_paserk);
+        let id_from_key = Id::from(&valid_paserk);
+        let mut buf = String::new();
+        id_from_key.fmt(&mut buf).unwrap();
+        let id_from_string = Id::try_from(buf.as_str()).unwrap();
+        assert_eq!(id_from_key, id_from_string);
     }
 
     if let Ok(valid_paserk) = SymmetricKey::<V2>::try_from(data.as_str()) {
         let mut buf = String::new();
         valid_paserk.fmt(&mut buf).unwrap();
         assert_eq!(&data, &buf);
-        let _ = Id::from(&valid_paserk);
+        let id_from_key = Id::from(&valid_paserk);
+        let mut buf = String::new();
+        id_from_key.fmt(&mut buf).unwrap();
+        let id_from_string = Id::try_from(buf.as_str()).unwrap();
+        assert_eq!(id_from_key, id_from_string);
     }
     if let Ok(valid_paserk) = SymmetricKey::<V4>::try_from(data.as_str()) {
         let mut buf = String::new();
         valid_paserk.fmt(&mut buf).unwrap();
         assert_eq!(&data, &buf);
-        let _ = Id::from(&valid_paserk);
+        let id_from_key = Id::from(&valid_paserk);
+        let mut buf = String::new();
+        id_from_key.fmt(&mut buf).unwrap();
+        let id_from_string = Id::try_from(buf.as_str()).unwrap();
+        assert_eq!(id_from_key, id_from_string);
     }
 });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,6 +226,10 @@ pub mod version4;
 /// Types for handling tokens.
 pub mod token;
 
+#[cfg(feature = "serde")]
+/// Serialization and deserialization support for various types.
+pub mod serde;
+
 mod version;
 
 /// Public and local tokens.

--- a/src/paserk.rs
+++ b/src/paserk.rs
@@ -1,13 +1,10 @@
 #![cfg_attr(docsrs, doc(cfg(feature = "paserk")))]
 
-#[cfg(feature = "serde")]
-mod serde;
-
 use crate::common::{decode_b64, encode_b64};
 use crate::errors::Error;
 use crate::keys::{AsymmetricPublicKey, AsymmetricSecretKey, SymmetricKey};
 use crate::version::private::Version;
-use alloc::string::String;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 use core::fmt::Write;
@@ -389,6 +386,7 @@ impl FormatAsPaserk for Id {
     }
 }
 
+#[cfg(any(feature = "v2", feature = "v3", feature = "v4"))]
 impl TryFrom<&str> for Id {
     type Error = Error;
 
@@ -483,6 +481,7 @@ mod tests {
                             continue;
                         }
                         (false, Some(paserk), Some(key)) => {
+                            #[cfg(feature = "serde")]
                             let key_hex = key.clone();
                             let deser = $key::<$version>::try_from(paserk.as_str()).unwrap();
                             let key = $key::<$version>::from(&hex::decode(&key).unwrap()).unwrap();
@@ -533,6 +532,7 @@ mod tests {
                             continue;
                         }
                         (false, Some(paserk), Some(key)) => {
+                            #[cfg(feature = "serde")]
                             let key_hex = key.clone();
                             let key = $key::<$version>::from(&hex::decode(&key).unwrap()).unwrap();
 

--- a/src/paserk/serde.rs
+++ b/src/paserk/serde.rs
@@ -1,0 +1,89 @@
+use super::{AsymmetricPublicKey, AsymmetricSecretKey, FormatAsPaserk, SymmetricKey};
+use std::convert::TryFrom;
+
+impl<V> serde::Serialize for AsymmetricPublicKey<V>
+where
+    AsymmetricPublicKey<V>: FormatAsPaserk,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::Error;
+        let mut paserk_string = String::new();
+        self.fmt(&mut paserk_string).map_err(S::Error::custom)?;
+        serializer.serialize_str(&paserk_string)
+    }
+}
+
+impl<'de, V> serde::Deserialize<'de> for AsymmetricPublicKey<V>
+where
+    AsymmetricPublicKey<V>: TryFrom<&'de str>,
+    <AsymmetricPublicKey<V> as TryFrom<&'de str>>::Error: std::fmt::Display,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let paserk_string = <&str>::deserialize(deserializer)?;
+        TryFrom::try_from(paserk_string).map_err(serde::de::Error::custom)
+    }
+}
+
+impl<V> serde::Serialize for AsymmetricSecretKey<V>
+where
+    AsymmetricSecretKey<V>: FormatAsPaserk,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::Error;
+        let mut paserk_string = String::new();
+        self.fmt(&mut paserk_string).map_err(S::Error::custom)?;
+        serializer.serialize_str(&paserk_string)
+    }
+}
+
+impl<'de, V> serde::Deserialize<'de> for AsymmetricSecretKey<V>
+where
+    AsymmetricSecretKey<V>: TryFrom<&'de str>,
+    <AsymmetricSecretKey<V> as TryFrom<&'de str>>::Error: std::fmt::Display,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let paserk_string = <&str>::deserialize(deserializer)?;
+        TryFrom::try_from(paserk_string).map_err(serde::de::Error::custom)
+    }
+}
+
+impl<V> serde::Serialize for SymmetricKey<V>
+where
+    SymmetricKey<V>: FormatAsPaserk,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::Error;
+        let mut paserk_string = String::new();
+        self.fmt(&mut paserk_string).map_err(S::Error::custom)?;
+        serializer.serialize_str(&paserk_string)
+    }
+}
+
+impl<'de, V> serde::Deserialize<'de> for SymmetricKey<V>
+where
+    SymmetricKey<V>: TryFrom<&'de str>,
+    <SymmetricKey<V> as TryFrom<&'de str>>::Error: std::fmt::Display,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let paserk_string = <&str>::deserialize(deserializer)?;
+        TryFrom::try_from(paserk_string).map_err(serde::de::Error::custom)
+    }
+}

--- a/src/paserk/serde.rs
+++ b/src/paserk/serde.rs
@@ -1,4 +1,4 @@
-use super::{AsymmetricPublicKey, AsymmetricSecretKey, FormatAsPaserk, SymmetricKey};
+use super::{AsymmetricPublicKey, AsymmetricSecretKey, FormatAsPaserk, Id, SymmetricKey};
 use std::convert::TryFrom;
 
 impl<V> serde::Serialize for AsymmetricPublicKey<V>
@@ -85,5 +85,27 @@ where
     {
         let paserk_string = <&str>::deserialize(deserializer)?;
         TryFrom::try_from(paserk_string).map_err(serde::de::Error::custom)
+    }
+}
+
+impl serde::Serialize for Id {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::Error;
+        let mut paserk_id = String::new();
+        self.fmt(&mut paserk_id).map_err(S::Error::custom)?;
+        serializer.serialize_str(&paserk_id)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Id {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let paserk_id = <&str>::deserialize(deserializer)?;
+        TryFrom::try_from(paserk_id).map_err(serde::de::Error::custom)
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,6 +1,11 @@
-use super::{AsymmetricPublicKey, AsymmetricSecretKey, FormatAsPaserk, Id, SymmetricKey};
-use std::convert::TryFrom;
+use crate::keys::{AsymmetricPublicKey, AsymmetricSecretKey, SymmetricKey};
+#[cfg(feature = "paserk")]
+use crate::paserk::{FormatAsPaserk, Id};
+use alloc::string::String;
+use core::convert::TryFrom;
 
+#[cfg(all(feature = "paserk", feature = "serde"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "paserk", feature = "serde"))))]
 impl<V> serde::Serialize for AsymmetricPublicKey<V>
 where
     AsymmetricPublicKey<V>: FormatAsPaserk,
@@ -16,6 +21,8 @@ where
     }
 }
 
+#[cfg(all(feature = "serde", feature = "std"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "serde", feature = "std"))))]
 impl<'de, V> serde::Deserialize<'de> for AsymmetricPublicKey<V>
 where
     AsymmetricPublicKey<V>: TryFrom<&'de str>,
@@ -30,6 +37,8 @@ where
     }
 }
 
+#[cfg(all(feature = "paserk", feature = "serde"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "paserk", feature = "serde"))))]
 impl<V> serde::Serialize for AsymmetricSecretKey<V>
 where
     AsymmetricSecretKey<V>: FormatAsPaserk,
@@ -45,6 +54,8 @@ where
     }
 }
 
+#[cfg(all(feature = "serde", feature = "std"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "serde", feature = "std"))))]
 impl<'de, V> serde::Deserialize<'de> for AsymmetricSecretKey<V>
 where
     AsymmetricSecretKey<V>: TryFrom<&'de str>,
@@ -59,6 +70,8 @@ where
     }
 }
 
+#[cfg(all(feature = "paserk", feature = "serde"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "paserk", feature = "serde"))))]
 impl<V> serde::Serialize for SymmetricKey<V>
 where
     SymmetricKey<V>: FormatAsPaserk,
@@ -74,6 +87,8 @@ where
     }
 }
 
+#[cfg(all(feature = "serde", feature = "std"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "serde", feature = "std"))))]
 impl<'de, V> serde::Deserialize<'de> for SymmetricKey<V>
 where
     SymmetricKey<V>: TryFrom<&'de str>,
@@ -88,6 +103,8 @@ where
     }
 }
 
+#[cfg(all(feature = "paserk", feature = "serde"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "paserk", feature = "serde"))))]
 impl serde::Serialize for Id {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -100,6 +117,11 @@ impl serde::Serialize for Id {
     }
 }
 
+#[cfg(all(feature = "paserk", feature = "serde", feature = "std"))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(feature = "paserk", feature = "serde", feature = "std")))
+)]
 impl<'de> serde::Deserialize<'de> for Id {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/version.rs
+++ b/src/version.rs
@@ -23,6 +23,9 @@ pub(crate) mod private {
         const PUBLIC_HEADER: &'static str;
         /// Header for a local token for this version.
         const LOCAL_HEADER: &'static str;
+        /// Size of a PASERK ID.
+        #[cfg(feature = "paserk")]
+        const PASERK_ID: usize;
 
         /// Validate bytes for a `local` key of a given version.
         fn validate_local_key(key_bytes: &[u8]) -> Result<(), Error>;

--- a/src/version2.rs
+++ b/src/version2.rs
@@ -32,6 +32,8 @@ impl Version for V2 {
     const LOCAL_TAG: usize = 16;
     const PUBLIC_HEADER: &'static str = "v2.public.";
     const LOCAL_HEADER: &'static str = "v2.local.";
+    #[cfg(feature = "paserk")]
+    const PASERK_ID: usize = 44;
 
     fn validate_local_key(key_bytes: &[u8]) -> Result<(), Error> {
         if key_bytes.len() != Self::LOCAL_KEY {

--- a/src/version3.rs
+++ b/src/version3.rs
@@ -46,6 +46,8 @@ impl Version for V3 {
     const LOCAL_TAG: usize = 48;
     const PUBLIC_HEADER: &'static str = "v3.public.";
     const LOCAL_HEADER: &'static str = "v3.local.";
+    #[cfg(feature = "paserk")]
+    const PASERK_ID: usize = 44;
 
     fn validate_local_key(_key_bytes: &[u8]) -> Result<(), Error> {
         unimplemented!();

--- a/src/version4.rs
+++ b/src/version4.rs
@@ -34,6 +34,8 @@ impl Version for V4 {
     const LOCAL_TAG: usize = 32;
     const PUBLIC_HEADER: &'static str = "v4.public.";
     const LOCAL_HEADER: &'static str = "v4.local.";
+    #[cfg(feature = "paserk")]
+    const PASERK_ID: usize = 44;
 
     fn validate_local_key(key_bytes: &[u8]) -> Result<(), Error> {
         if key_bytes.len() != Self::LOCAL_KEY {


### PR DESCRIPTION
This PR introduces a `serde` feature which enables the `serde` support for keys to be de/serialized from/to PASERK strings, and PASERK IDs from/to strings. The corresponding unit tests have also been updated. 

Closes #26.