### PR TITLE
v3: Update test vectors with normalized S value sigs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,29 +8,29 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.72.0 # MSRV
+          - 1.80.0 # MSRV
           - nightly
-    
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
           persist-credentials: false
-      
+
       - name: Install toolchain
         uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      
+
       - name: Test debug-mode
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505
         with:
           command: test
           args: --all-features
-      
+
       - name: Test release-mode
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505
         with:
@@ -48,7 +48,7 @@ jobs:
         with:
           command: test
           args: --no-default-features --tests --features v2,std,paserk
-      
+
       - name: Test only v3-full
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 __Date:__ TBD
 
-- Bump MSRV to `1.72`.
+- Bump MSRV to `1.80`.
+- Updated test vectors for `v3.public`.
 
 ### 0.6.8
 
@@ -95,8 +96,8 @@ __Changelog:__
 - Stricter permissions for GH Actions workflows ([#43](https://github.com/brycx/pasetors/pull/43))
 - Add `Generate` trait and implement this for all key-types, removing also `SymmetricKey::gen()` ([#45](https://github.com/brycx/pasetors/issues/45))
 - Switch from `ed25519-dalek` to `ed25519-compact` ([#48](https://github.com/brycx/pasetors/issues/48))
-- Add new types `token::UntrustedToken` and `token::TrustedToken` which are now used by `verify()`/`decrypt()` operations. 
-These allow extracting parts of tokens before and after verification ([#47](https://github.com/brycx/pasetors/issues/47)) 
+- Add new types `token::UntrustedToken` and `token::TrustedToken` which are now used by `verify()`/`decrypt()` operations.
+These allow extracting parts of tokens before and after verification ([#47](https://github.com/brycx/pasetors/issues/47))
 - Version structs previously available in `keys::` have been moved to a new `version::` module
 - Add `Footer` type that makes it easier to create JSON-encoded footers ([#52](https://github.com/brycx/pasetors/pull/52))
 - PASERK deserialization of keys now takes `&str` instead of `String` ([#53](https://github.com/brycx/pasetors/issues/53))
@@ -150,7 +151,7 @@ __Changelog:__
 - Update Orion to `0.16`
 
 
-### 0.1.1 
+### 0.1.1
 
 __Date:__ March 21, 2021.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "pasetors"
-version = "0.6.8" # Update html_root_url in lib.rs along with this.
+version = "0.6.8"                                                          # Update html_root_url in lib.rs along with this.
 authors = ["brycx <brycx@protonmail.com>"]
 edition = "2018"
 description = "PASETO: Platform-Agnostic Security Tokens (in Rust)"
-keywords = [ "cryptography", "crypto", "token", "paseto", "authentication" ]
-categories = [ "cryptography", "authentication" ]
+keywords = ["cryptography", "crypto", "token", "paseto", "authentication"]
+categories = ["cryptography", "authentication"]
 readme = "README.md"
 repository = "https://github.com/brycx/pasetors"
 documentation = "https://docs.rs/pasetors"
 license = "MIT"
-rust-version = "1.72.0" # Update CI test along with this.
+rust-version = "1.80.0"                                                    # Update CI test along with this.
 
 [package.metadata.docs.rs]
 all-features = true
@@ -34,7 +34,7 @@ optional = true
 
 [dependencies.getrandom]
 version = "0.2"
-features = [ "js" ]
+features = ["js"]
 
 [dependencies.ct-codecs]
 version = "1.1.1"
@@ -80,9 +80,9 @@ version = "1.0.145"
 optional = true
 
 [features]
-default = [ "std", "v4", "paserk" ]
-std = [ "serde_json", "time", "regex" ]
-v2 = [ "orion", "ed25519-compact" ]
-v3 = [ "rand_core", "p384", "sha2" ]
-v4 = [ "orion", "ed25519-compact" ]
-paserk = [ "orion" ]
+default = ["std", "v4", "paserk"]
+std = ["serde_json", "time", "regex"]
+v2 = ["orion", "ed25519-compact"]
+v3 = ["rand_core", "p384", "sha2"]
+v4 = ["orion", "ed25519-compact"]
+paserk = ["orion"]

--- a/src/pae.rs
+++ b/src/pae.rs
@@ -3,8 +3,8 @@ use alloc::vec::Vec;
 use core::convert::TryInto;
 
 /// Encode `n` to little-endian bytes. The MSB is cleared.
-pub fn le64(n: u64) -> [u8; core::mem::size_of::<u64>()] {
-    let mut out = [0u8; core::mem::size_of::<u64>()];
+pub fn le64(n: u64) -> [u8; size_of::<u64>()] {
+    let mut out = [0u8; size_of::<u64>()];
     let mut n_tmp = n;
 
     out[0] = (n_tmp & 255) as u8;

--- a/src/version3.rs
+++ b/src/version3.rs
@@ -370,11 +370,17 @@ mod test_vectors {
         }
 
         let message = test.payload.as_ref().unwrap().as_str().unwrap();
+
         let actual =
             PublicToken::sign(&sk, message.as_bytes(), footer, Some(implicit_assert)).unwrap();
-        assert_eq!(actual, test.token, "Failed {:?}", test.name);
-        let ut = UntrustedToken::<Public, V3>::try_from(&test.token).unwrap();
+        let ut = UntrustedToken::<Public, V3>::try_from(&actual).unwrap();
+        let trusted = PublicToken::verify(&pk, &ut, footer, Some(implicit_assert)).unwrap();
+        assert_eq!(trusted.payload(), message);
+        assert_eq!(trusted.footer(), test.footer.as_bytes());
+        assert_eq!(trusted.header(), PublicToken::HEADER);
+        assert_eq!(trusted.implicit_assert(), implicit_assert);
 
+        let ut = UntrustedToken::<Public, V3>::try_from(&test.token).unwrap();
         let trusted = PublicToken::verify(&pk, &ut, footer, Some(implicit_assert)).unwrap();
         assert_eq!(trusted.payload(), message);
         assert_eq!(trusted.footer(), test.footer.as_bytes());

--- a/test_vectors/v3.json
+++ b/test_vectors/v3.json
@@ -98,7 +98,7 @@
       "secret-key": "20347609607477aca8fbfbc5e6218455f3199669792ef8b466faa87bdc67798144c848dd03661eed5ac62461340cea96",
       "secret-key-pem": "-----BEGIN EC PRIVATE KEY-----\nMIGkAgEBBDAgNHYJYHR3rKj7+8XmIYRV8xmWaXku+LRm+qh73Gd5gUTISN0DZh7t\nWsYkYTQM6pagBwYFK4EEACKhZANiAAT7y3xp7hxgV5vnozQTSHjZxcW/NdVS2rY8\nAUA5ftFM72N9dyCSXERpnqMOcodMcvt8kgcrB8KcKee0HU23E79/s4CvEs8hBfnj\nSUd/gcAm08EjSIz06iWjrNy4NakxR3I=\n-----END EC PRIVATE KEY-----",
       "public-key-pem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+8t8ae4cYFeb56M0E0h42cXFvzXVUtq2\nPAFAOX7RTO9jfXcgklxEaZ6jDnKHTHL7fJIHKwfCnCnntB1NtxO/f7OArxLPIQX5\n40lHf4HAJtPBI0iM9Oolo6zcuDWpMUdy\n-----END PUBLIC KEY-----",
-      "token": "v3.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9qqEwwrKHKi5lJ7b9MBKc0G4MGZy0ptUiMv3lAUAaz-JY_zjoqBSIxMxhfAoeNYiSyvfUErj76KOPWm1OeNnBPkTSespeSXDGaDfxeIrl3bRrPEIy7tLwLAIsRzsXkfph",
+      "token": "v3.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9vrarT0tBPumLsUh5iJGDDH7sIkPk1fW8Ej6R2j-8jB7rkkCJyEKxcMNPJ5jLurPvZSzRdLb-Ia_Y2YXavY77xbLzJQJkA_zjJeYrd8mWQ24oOpkts1Css3Xa74cz_j3A",
       "payload": "{\"data\":\"this is a signed message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
       "footer": "",
       "implicit-assertion": ""
@@ -122,7 +122,7 @@
       "secret-key": "20347609607477aca8fbfbc5e6218455f3199669792ef8b466faa87bdc67798144c848dd03661eed5ac62461340cea96",
       "secret-key-pem": "-----BEGIN EC PRIVATE KEY-----\nMIGkAgEBBDAgNHYJYHR3rKj7+8XmIYRV8xmWaXku+LRm+qh73Gd5gUTISN0DZh7t\nWsYkYTQM6pagBwYFK4EEACKhZANiAAT7y3xp7hxgV5vnozQTSHjZxcW/NdVS2rY8\nAUA5ftFM72N9dyCSXERpnqMOcodMcvt8kgcrB8KcKee0HU23E79/s4CvEs8hBfnj\nSUd/gcAm08EjSIz06iWjrNy4NakxR3I=\n-----END EC PRIVATE KEY-----",
       "public-key-pem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+8t8ae4cYFeb56M0E0h42cXFvzXVUtq2\nPAFAOX7RTO9jfXcgklxEaZ6jDnKHTHL7fJIHKwfCnCnntB1NtxO/f7OArxLPIQX5\n40lHf4HAJtPBI0iM9Oolo6zcuDWpMUdy\n-----END PUBLIC KEY-----",
-      "token": "v3.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ94SjWIbjmS7715GjLSnHnpJrC9Z-cnwK45dmvnVvCRQDCCKAXaKEopTajX0DKYx1Xqr6gcTdfqscLCAbiB4eOW9jlt-oNqdG8TjsYEi6aloBfTzF1DXff_45tFlnBukEX.eyJraWQiOiJkWWtJU3lseFFlZWNFY0hFTGZ6Rjg4VVpyd2JMb2xOaUNkcHpVSEd3OVVxbiJ9",
+      "token": "v3.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9FrkqK6FaB39LisqmPmIHLnu5P8zBTdO_EyWqeworXkGMBChHk-ZZWPt2r7qSYpOqWmvf0oBgf9Elx1TKS4a3YKIcaYddPlu6B9w5LT_b76sCqdVDjE5bH8ZgvZ708c48.eyJraWQiOiJkWWtJU3lseFFlZWNFY0hFTGZ6Rjg4VVpyd2JMb2xOaUNkcHpVSEd3OVVxbiJ9",
       "payload": "{\"data\":\"this is a signed message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
       "footer": "{\"kid\":\"dYkISylxQeecEcHELfzF88UZrwbLolNiCdpzUHGw9Uqn\"}",
       "implicit-assertion": "{\"test-vector\":\"3-S-3\"}"


### PR DESCRIPTION
closes #122 

Before this change, we had the signatures generated by `v3.public` be tested to be reproducible. Such that we given the same input could generate the same token. This is possible because we employ deterministic nonces.

New test vectors for `v3.public` have been issued (https://github.com/paseto-standard/test-vectors/releases/tag/v1.3.0) to only include low-S/normalized S. These test vectors we can't reproduce the tokens for, and thus that part of the tests have been removed. Justification of removal:

- The spec doesn't _require_ use of deterministic nonces, which `pasetors` uses, but encourages it: https://github.com/paseto-standard/paseto-spec/blob/master/docs/01-Protocol-Versions/Version3.md#sign This is what enabled us to perform the reproducebility tests in the first place. Since it isn't a requirement, we won't be incompatible with the spec when not testing for this (other impls cannot be expected to be deterministic for example).
- The reference impl does not seem to test for reproducebility like we have: https://github.com/paragonie/paseto/blob/abecd5ab79d78483bc10786e27d935300e4ed3ec/tests/Version3Test.php#L140 This, again, makes sense taken the specification of `v3.public` into consideration.

Note: During tests with the new vectors and using `elliptic-curve`'s provided `normalize_s()` internally for the signature, didn't reproduce either, suggesting maybe the new test vectors were generated non-deterministically or the normalization routine used in generation of them differed somehow.