### PR TITLE
Build `serde` and `serde_derive` in parallel (22% faster builds)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dev-dependencies]
 hex = "0.4.2"
 serde_json = "1.0.41"
-serde = { version = "1.0", features = ["derive"] }
+serde = "1.0"
+serde_derive = "1.0"
 
 [dependencies.ed25519-compact]
 version = "2.0.2"

--- a/src/common.rs
+++ b/src/common.rs
@@ -53,7 +53,7 @@ pub(crate) fn validate_footer_untrusted_token<T: Purpose<V>, V: Version>(
 pub(crate) mod tests {
     use alloc::string::String;
     use alloc::vec::Vec;
-    use serde::{Deserialize, Serialize};
+    use serde_derive::{Deserialize, Serialize};
     use serde_json::Value;
 
     #[allow(non_snake_case)]

--- a/src/paserk.rs
+++ b/src/paserk.rs
@@ -433,7 +433,7 @@ impl TryFrom<&str> for Id {
 mod tests {
     use super::*;
 
-    use ::serde::{Deserialize, Serialize};
+    use ::serde_derive::{Deserialize, Serialize};
     use alloc::string::String;
     use alloc::vec::Vec;
     use hex;

--- a/src/version3.rs
+++ b/src/version3.rs
@@ -412,7 +412,7 @@ mod test_wycheproof_point_compression {
     use alloc::string::String;
     use alloc::vec::Vec;
     use p384::elliptic_curve::sec1::ToEncodedPoint;
-    use serde::{Deserialize, Serialize};
+    use serde_derive::{Deserialize, Serialize};
     use std::convert::TryFrom;
     use std::fs::File;
     use std::io::BufReader;


### PR DESCRIPTION
Before:

    $ hyperfine --prepare "cargo clean" 'cargo build --tests'
    Benchmark 1: cargo build --tests
      Time (mean ± σ):      6.546 s ±  0.153 s    [User: 20.745 s, System: 3.745 s]
      Range (min … max):    6.241 s …  6.853 s    10 runs

After:

    $ hyperfine --prepare "cargo clean" 'cargo build --tests'
    Benchmark 1: cargo build --tests
      Time (mean ± σ):      5.100 s ±  0.117 s    [User: 21.400 s, System: 3.917 s]
      Range (min … max):    4.956 s …  5.276 s    10 runs

The version mismatch problem that prohibited doing this earlier was fixed almost [2 years
ago](https://github.com/serde-rs/serde/issues/2584#issuecomment-2938307179).

(Not doing this prevents downstream projects from performing the same build time optimization since cargo features are
[additive](https://doc.rust-lang.org/cargo/reference/resolver.html#features) across the dependency graph.)