### PR TITLE
 Build `serde` and `serde_derive` in parallel (fixup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 0.7.6
+
+__Date:__ June 7, 2025.
+
+- Fixup for "Build serde and serde_derive in parallel" ([#192](https://github.com/brycx/pasetors/pull/192), credits: [@Enselic](https://github.com/Enselic)).
+
 ### 0.7.5
 
 __Date:__ June 7, 2025.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,10 +79,14 @@ optional = true
 [dependencies.serde]
 version = "1.0"
 optional = true
-features = ["derive"]
+
+[dependencies.serde_derive]
+version = "1.0"
+optional = true
 
 [features]
 default = ["std", "v4", "paserk"]
+serde = ["dep:serde", "dep:serde_derive"]
 std = ["serde_json", "time", "regex"]
 v2 = ["orion", "ed25519-compact"]
 v3 = ["rand_core", "p384", "sha2"]

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -8,7 +8,10 @@ use time::format_description::well_known::Rfc3339;
 use time::{Duration, OffsetDateTime};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 /// A collection of claims that are passed as payload for a PASETO token.
 pub struct Claims {
     #[cfg_attr(feature = "serde", serde(flatten))]

--- a/src/token.rs
+++ b/src/token.rs
@@ -88,7 +88,10 @@ impl<V: Version> Purpose<V> for Local {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 /// A [`TrustedToken`] is returned by either a `verify()` or `decrypt()` operation and represents
 /// a validated token.
 ///
@@ -199,7 +202,10 @@ impl TryFrom<&TrustedToken> for Footer {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 /// [`UntrustedToken`] can parse PASETO tokens in order to extract individual parts of it.
 ///
 /// A use-case for this would be parsing the tokens footer, if this is not known before receiving it. Then,


### PR DESCRIPTION
 I forgot to change the non-dev dependency in 7f0a9ae. Fixed in this commit.

Explicitly declare the `serde` feature and make it also contain `serde_derive`. Previously this feature existed but was implicitly declared as `serde = ["dep:serde"]`. See https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies for more info.